### PR TITLE
Allow ending bantustans if black anglo dominant #6

### DIFF
--- a/CWE/decisions/south_africa.txt
+++ b/CWE/decisions/south_africa.txt
@@ -132,16 +132,20 @@ political_decisions = {
 				exists = VED
 				exists = ZUL
 			}
-			NOT = { has_country_modifier = apartheid }
+			OR = {
+				NOT = { has_country_modifier = apartheid }
+				primary_culture = black_anglo #can add more clauses for other apartheid cultures
+			}
 		}
 
 		allow = {
-			government = democracy
+			#government = democracy
 			#cultural_imperialism = 1
 			war = no
 		}
 
 		effect = {
+			remove_country_modifier = apartheid
 			any_country = { 
 				limit = { 
 					vassal_of = THIS


### PR DESCRIPTION
Observed behavior: AI South Africa ends Bantustans if communist, does nothing if not.
Ending apartheid this way does not relinquish the core on Walvis Bay if Namibia exists, as the original method does. I'm not sure if it should, since it is uncertain whether Namibia will exist, and there is a decision just to return it. In the end, the only difference should be the amount of infamy lost.