### PR TITLE
Arabia will not enact wahhabism if atheist #12

### DIFF
--- a/CWE/decisions/saudi_arabia.txt
+++ b/CWE/decisions/saudi_arabia.txt
@@ -13,7 +13,13 @@ political_decisions = {
 			money = 100000
 		}
 
-		ai_will_do = { factor = 1 }
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				religious_policy = pro_atheism
+			}
+		}
 
 		effect = {
 			add_country_modifier = { duration = 1500 name = wahhabism }


### PR DESCRIPTION
This ignores the status of the "religious rights" reform. It may be better to use its status in conjunction with party policy, especially as it seems to be more or less fluid. 