### PR TITLE
Yugoslav ethnic cleansing fix

### DIFF
--- a/CWE/decisions/ethnic_cleansing.txt
+++ b/CWE/decisions/ethnic_cleansing.txt
@@ -15,20 +15,22 @@ political_decisions = {
 			}
 
 			allow = {
-OR = { ai = no 
+			is_vassal = no #Yugoslav states under 1974 constitution
+			OR = {
+				ai = no 
 
-AND = { ai = yes tag = RWA revolt_percentage = 0.80 } 
-AND = { ai = yes tag = RSR war = yes }
-AND = { ai = yes tag = SRK war = yes }
-AND = { ai = yes tag = SER war = yes }
-AND = { ai = yes tag = CRO war = yes }
-AND = { ai = yes tag = BOS war = yes }
+				AND = { ai = yes tag = RWA revolt_percentage = 0.80 } 
+				AND = { ai = yes tag = RSR war = yes }
+				AND = { ai = yes tag = SRK war = yes }
+				AND = { ai = yes tag = SER war = yes }
+				AND = { ai = yes tag = CRO war = yes }
+				AND = { ai = yes tag = BOS war = yes }
 
-AND = { average_militancy = 9 citizenship_policy = residency revolt_percentage = 0.80 }
-AND = { jingoism = 24
-wars_of_national_liberation = 1
-war = yes } }
-		}
+				AND = { average_militancy = 9 citizenship_policy = residency revolt_percentage = 0.80 }
+				AND = { jingoism = 24
+				wars_of_national_liberation = 1
+				war = yes } }
+			}
 
 			effect = {
 				set_country_flag = ethnic_cleansed


### PR DESCRIPTION
Prevent Croatia, Bosnia, etc. from ethnic cleansing when they are puppets of Yugoslavia as part of the 1974 constitution event.
Maybe this is better as part of potential rather than allow? Seems like a player interface question.