### PR TITLE
Remove communist CB from puppet wars #22

### DIFF
--- a/CWE/events/finland.txt
+++ b/CWE/events/finland.txt
@@ -134,7 +134,12 @@ country_event = {
   option = {
     name = EVT_8005526_B
 	any_pop = { militancy = 1.0 consciousness = 1 }
-	war = { target = FIN attacker_goal = { casus_belli = install_communist_gov_cb } attacker_goal = { casus_belli = make_puppet } defender_goal = { casus_belli = status_quo } }
+	war = {
+		target = FIN
+		#attacker_goal = { casus_belli = install_communist_gov_cb }
+		attacker_goal = { casus_belli = make_puppet }
+		defender_goal = { casus_belli = status_quo }
+	}
 	badboy = 10
 	money = -500
 	ai_chance = { factor = 0 }

--- a/CWE/events/vietnam_war.txt
+++ b/CWE/events/vietnam_war.txt
@@ -953,7 +953,14 @@ country_event = {
 
   option = {
     name = EVT_8228201_A
-	DAI = { war = { target = LUA attacker_goal = { casus_belli = make_puppet } attacker_goal = { casus_belli = install_communist_gov_cb } defender_goal = { casus_belli = status_quo } } } 
+	DAI = {
+		war = {
+			target = LUA
+			attacker_goal = { casus_belli = make_puppet }
+			#attacker_goal = { casus_belli = install_communist_gov_cb }
+			defender_goal = { casus_belli = status_quo } 
+		}
+	} 
 	ai_chance = { factor = 100 }
    }
   


### PR DESCRIPTION
I've left the events that give both CBs but do not declare the war, leaving the country to do it. I don't think this will cause problems, as the player would not add the other CB if they see warscore will exceed 100, and I doubt the AI would.