### PR TITLE
Fix superstate expansion infinite prestige bug

### DIFF
--- a/CWE/decisions/african_union.txt
+++ b/CWE/decisions/african_union.txt
@@ -207,7 +207,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xau_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/andean_community.txt
+++ b/CWE/decisions/andean_community.txt
@@ -208,7 +208,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xac_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/arab_league.txt
+++ b/CWE/decisions/arab_league.txt
@@ -233,7 +233,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xal_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/arab_maghreb_union.txt
+++ b/CWE/decisions/arab_maghreb_union.txt
@@ -201,7 +201,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xmu_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/arabia.txt
+++ b/CWE/decisions/arabia.txt
@@ -192,7 +192,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xgc_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/asean.txt
+++ b/CWE/decisions/asean.txt
@@ -203,7 +203,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xan_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/caricom.txt
+++ b/CWE/decisions/caricom.txt
@@ -207,7 +207,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xcc_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/central_africa.txt
+++ b/CWE/decisions/central_africa.txt
@@ -206,7 +206,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xec_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/central_america.txt
+++ b/CWE/decisions/central_america.txt
@@ -206,7 +206,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xci_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/east_africa.txt
+++ b/CWE/decisions/east_africa.txt
@@ -209,7 +209,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xef_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/eurasia.txt
+++ b/CWE/decisions/eurasia.txt
@@ -329,7 +329,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_country = { limit = { has_country_flag = xea_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/indian_subcontinent.txt
+++ b/CWE/decisions/indian_subcontinent.txt
@@ -200,7 +200,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xio_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/mercosur.txt
+++ b/CWE/decisions/mercosur.txt
@@ -209,7 +209,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xms_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/north_america.txt
+++ b/CWE/decisions/north_america.txt
@@ -210,7 +210,6 @@ any_neighbor_country = { has_country_flag = xna_ambition in_sphere = THIS NOT = 
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xna_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/pacific_federation.txt
+++ b/CWE/decisions/pacific_federation.txt
@@ -206,7 +206,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xpi_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/south_american_union.txt
+++ b/CWE/decisions/south_american_union.txt
@@ -295,7 +295,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xsu_ambition in_sphere = THIS } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/southern_african_community.txt
+++ b/CWE/decisions/southern_african_community.txt
@@ -208,7 +208,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xsa_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/turkic_union.txt
+++ b/CWE/decisions/turkic_union.txt
@@ -199,7 +199,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xtc_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/ummah.txt
+++ b/CWE/decisions/ummah.txt
@@ -200,7 +200,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xum_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/decisions/west_africa.txt
+++ b/CWE/decisions/west_africa.txt
@@ -207,7 +207,6 @@ political_decisions = {
             war = no
 		}
 		effect = {
-			prestige = 20
 			any_neighbor_country = { limit = { has_country_flag = xew_ambition OR = { vassal_of = THIS in_sphere = THIS } } country_event = 11106 }
 		}
 		ai_will_do = {

--- a/CWE/events/political_national_unification.txt
+++ b/CWE/events/political_national_unification.txt
@@ -49,7 +49,7 @@ country_event = {
 	option = {
 		name = "EVT_11107_A"
 		inherit = FROM
-		prestige = 20
+		prestige = 40
 		ai_chance = { factor = 100 }
 	}
 


### PR DESCRIPTION
While paused, player can click the "expand superstate" decision infinite times, which gives 20 prestige each time. Since it's 20 for the decision and 20 for the annexation, I took off the 20 for the decision and made 40 for the annexation.

Note: I noticed one of the unions, the Imperial Federation, never gave any prestige for the decision. If this was done for balance, a -20 could be added to the decision to get the same result as before.