### PR TITLE
International media now reports on terror + fixes

### DIFF
--- a/CWE/events/Terrorism.txt
+++ b/CWE/events/Terrorism.txt
@@ -452,8 +452,8 @@ province_event = {
 	
 	option = {
 		name = EVT_1511119_A
-		prestige = -5
-		add_country_modifier = { name = recent_terrorist_attack duration = 183 }
+		owner = { prestige = -5 }
+		owner = { add_country_modifier = { name = recent_terrorist_attack duration = 183 } }
 		add_province_modifier = { name = terror_strike_impending duration = -1 }
 	}
 }
@@ -465,11 +465,13 @@ province_event = {
 	desc = EVTDESC1511110
 	#picture = "un_counter_terrorism_committee"
 	
+	major = yes
 	trigger = { has_province_modifier = terror_strike_impending }
 	mean_time_to_happen = { days = 6 }
 	
 	immediate = {
 		remove_province_modifier = terror_strike_impending
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 
 	option = {
@@ -486,18 +488,25 @@ province_event = {
 	desc = EVTDESC1511111
 	#picture = "un_counter_terrorism_committee"
 	
+	major = yes
 	trigger = { has_province_modifier = terror_strike_impending }
 	mean_time_to_happen = { days = 6 }
 
 	immediate = {
 		remove_province_modifier = terror_strike_impending
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 
 	option = {
 		name = "They'd better not take my guns..."
-		state_scope = { any_pop = {
-			dominant_issue = { value = pro_military factor = 0.35 }
-		} }
+		state_scope = {
+			poor_strata = {
+				dominant_issue = { value = pro_military factor = 0.45 }
+			}
+			middle_strata = {
+				dominant_issue = { value = pro_military factor = 0.35 }
+			}
+		}
 		add_province_modifier = { name = terrorist_chaos duration = 365 }
 	}
 
@@ -506,6 +515,7 @@ province_event = {
 		state_scope = { any_pop = {
 			dominant_issue = { value = pro_military factor = 0.05 }
 			militancy = 2
+			consciousness = -2
 		} }
 		add_province_modifier = { name = terrorist_chaos duration = 365 }
 		ai_chance = { factor = 0 }
@@ -519,6 +529,7 @@ province_event = {
 	desc = EVTDESC1511112
 	#picture = "un_counter_terrorism_committee"
 	
+	major = yes
 	trigger = { has_province_modifier = terror_strike_impending }
 	mean_time_to_happen = { days = 6 }
 
@@ -528,15 +539,16 @@ province_event = {
 	
 	option = {
 		name = "Pay the ransom"
-		money = -5000
+		owner = { money = -5000 }
 		add_province_modifier = { name = terrorist_chaos duration = 365 }
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 
 	option = {
 		name = "Attempt a hostage rescue operation"
 		random_list = {
-			1 =	{ prestige = 10 state_scope = { any_pop = { consciousness = -1 } } }
-			1 =	{ prestige = -20 state_scope = { any_pop = { militancy = -1 } } }
+			1 =	{ owner = { prestige = 10 } state_scope = { any_pop = { consciousness = -1 } } }
+			1 =	{ owner = { prestige = -20 } state_scope = { any_pop = { militancy = -1 } } owner = { country_event = { id = 1511120 days = 2 } } }
 		}
 		add_province_modifier = { name = terrorist_chaos duration = 365 }
 	}
@@ -557,13 +569,14 @@ province_event = {
 
 	immediate = {
 		remove_province_modifier = terror_strike_impending
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 	
 	option = {
 		name = "Oh, no"
-		prestige = -15
+		owner = { prestige = -15 }
 		add_province_modifier = { name = terrorist_chaos duration = 450 }
-		add_country_modifier = { name = shipping_insecurity duration = 60 }
+		owner = { add_country_modifier = { name = shipping_insecurity duration = 60 } }
 		state_scope = { any_pop = { dominant_issue = { value = jingoism factor = 0.5 } } }
 	}
 
@@ -578,19 +591,20 @@ province_event = {
 	
 	trigger = {
 		has_province_modifier = terror_strike_impending
-		location = { port = yes }
+		port = yes
 	}	
 	mean_time_to_happen = { days = 10 }
 
 	immediate = {
 		remove_province_modifier = terror_strike_impending
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 
 	option = {
 		name = "Oh, no"
-		prestige = -15
+		owner = { prestige = -15 }
 		add_province_modifier = { name = terrorist_chaos duration = 365 }
-		add_country_modifier = { name = shipping_insecurity duration = 30 }
+		owner = { add_country_modifier = { name = shipping_insecurity duration = 30 } }
 	}
 
 }
@@ -602,11 +616,13 @@ province_event = {
 	desc = EVTDESC1511115
 	#picture = "un_counter_terrorism_committee"
 
+	major = yes
 	trigger = { has_province_modifier = terror_strike_impending }
 	mean_time_to_happen = { days = 6 }
 
 	immediate = {
 		remove_province_modifier = terror_strike_impending
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 
 	option = {
@@ -629,11 +645,13 @@ province_event = {
 	desc = EVTDESC1511116
 	#picture = "un_counter_terrorism_committee"
 
+	major = yes
 	trigger = { has_province_modifier = terror_strike_impending }
 	mean_time_to_happen = { days = 10 }
 
 	immediate = {
 		remove_province_modifier = terror_strike_impending
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 
 	option = {
@@ -657,11 +675,13 @@ province_event = {
 	desc = EVTDESC1511117
 	#picture = "un_counter_terrorism_committee"
 	
+	major = yes
 	trigger = { has_province_modifier = terror_strike_impending }
 	mean_time_to_happen = { days = 10 }
 
 	immediate = {
 		remove_province_modifier = terror_strike_impending
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 	
 	option = {
@@ -679,11 +699,13 @@ province_event = {
 	desc = EVTDESC1511118
 	#picture = "un_counter_terrorism_committee"
 	
+	major = yes
 	trigger = { has_province_modifier = terror_strike_impending }
 	mean_time_to_happen = { days = 10 }
 
 	immediate = {
 		remove_province_modifier = terror_strike_impending
+		owner = { country_event = { id = 1511120 days = 2 } }
 	}
 	
 	option = {
@@ -691,6 +713,165 @@ province_event = {
 		add_province_modifier = { name = terrorist_chaos duration = 365 }
 	}
 
+}
+
+#Media reaction
+country_event = { #possibly disable this if missing free press?
+	id = 1511120
+	title = EVTNAME1511120
+	desc = EVTDESC1511120
+	picture = "un_counter_terrorism_committee"
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVT_1511120_A
+		prestige = -15
+		any_pop = {
+			ideology = {
+				value = conservative
+				factor = 0.025
+			}
+			dominant_issue = {
+				value = residency
+				factor = 0.01
+			}
+			dominant_issue = {
+				value = nobody_gets_out
+				factor = 0.01
+			}
+			consciousness = -1
+		}
+		upper_house = {
+			ideology = conservative
+			value = 0.1
+		}
+		random = {
+			chance = 75
+			random_country = {
+				limit = {
+					NOT = { tag = THIS }
+					NOT = { immigration_policy = nobody_gets_out }
+					NOT = {
+						publishing_rights = censored_publishing
+						internet_infrastructure = quality_of_service
+					}
+				}
+				country_event = 1511121
+			}
+		}
+		random = {
+			chance = 50
+			random_country = {
+				limit = {
+					NOT = { tag = THIS }
+					NOT = { immigration_policy = nobody_gets_out }
+					NOT = {
+						publishing_rights = censored_publishing
+						internet_infrastructure = quality_of_service
+					}
+				}
+				country_event = 1511121
+			}
+		}
+	}
+	
+	option = {
+		name = EVT_1511120_B
+		poor_strata = {
+			ideology = {
+				value = populist
+				factor = 0.05
+			}
+			consciousness = -2
+		}
+		middle_strata = {
+			ideology = {
+				value = populist
+				factor = 0.025
+			}
+			consciousness = -1
+		}
+		random = {
+			chance = 50
+			random_country = {
+				limit = {
+					NOT = { tag = THIS }
+					NOT = { immigration_policy = nobody_gets_out }
+					NOT = {
+						publishing_rights = censored_publishing
+						internet_infrastructure = quality_of_service
+					}
+				}
+				country_event = 1511121
+			}
+		}
+		random = {
+			chance = 25
+			random_country = {
+				limit = {
+					NOT = { tag = THIS }
+					NOT = { immigration_policy = nobody_gets_out }
+					NOT = {
+						publishing_rights = censored_publishing
+						internet_infrastructure = quality_of_service
+					}
+				}
+				country_event = 1511121
+			}
+		}
+	}
+}
+
+country_event = {
+	id = 1511121
+	title = EVTNAME1511121
+	desc = EVTDESC1511121
+	picture = "un_counter_terrorism_committee"
+	
+	is_triggered_only = yes
+	
+	immediate = {
+		poor_strata = {
+			ideology = {
+				value = populist
+				factor = 0.03
+			}
+		}
+		middle_strata = {
+			ideology = {
+				value = populist
+				factor = 0.02
+			}
+		}
+	}
+	
+	option = {
+		name = EVT_1511121_A
+		any_pop = {
+			dominant_issue = {
+				value = residency
+				factor = 0.02
+			}
+			dominant_issue = {
+				value = nobody_gets_out
+				factor = 0.02
+			}
+			consciousness = -1
+		}
+	}
+	
+	option = {
+		name = EVT_1511121_B
+		prestige = -10
+		upper_house = {
+			ideology = conservative
+			value = 0.1
+		}
+		any_pop = {
+			militancy = -0.5
+		}
+	}
 }
 
 ##############################################################

--- a/CWE/localisation/Terrorism.csv
+++ b/CWE/localisation/Terrorism.csv
@@ -51,6 +51,14 @@ EVTNAME1511117;Knifings in $PROVINCENAME$;;;;;;;;;;x
 EVTDESC1511117;A terrorist has gone on a crazed knifing spree in the heart of $PROVINCENAME$, killing several and wounding even more.;;;;;;;;;;x
 EVTNAME1511118;Terrorist drives vehicle into market;;;;;;;;;;x
 EVTDESC1511118;A terrorist has used a vehicle to mow down innocent bystanders in a crowded maket in the heart of $PROVINCENAME$, killing and wounding many.;;;;;;;;;;x
+EVTNAME1511120;Terror mobilizes the far-right!;;;;;;;;;;x
+EVTDESC1511120;One of the far-right-wing publications in our country, normally a fringe source of news, has published a scathing editorial in the aftermath of the attack, blaming our lax security measures and calling for a change in leadership. Normally this would be insignificant, but it seems that the shock of terror on home soil has brought the piece into the national spotlight.;;;;;;;;;;x
+EVT_1511120_A;Agree to make changes;;;;;;;;;;x
+EVT_1511120_B;Denounce it as fake news;;;;;;;;;;x
+EVTNAME1511121;National security called into question;;;;;;;;;;x
+EVTDESC1511121;While the whole world is in shock at the major terror attack in $FROMCOUNTRY$, a heated debate is beginning in $COUNTRY$ - could we be next? Recently, $FROMCOUNTRY_ADJ$ news sources have taken a right-wing spin and begun to demand national security changes. It seems that our own susceptibility in the eyes of our people have led to similar demands.;;;;;;;;;;x
+EVT_1511121_A;That could never happen here;;;;;;;;;;x
+EVT_1511121_B;Maybe it's for the best;;;;;;;;;;x
 1963_un_terror_convention_title;Ratify the 1963 UN Convention on Counter-Terrorism.;;;;;;;;x;;;;;;;;;;;;;
 1970_un_terror_convention_title;Ratify the 1970 UN Convention on Counter-Terrorism.;;;;;;;;x;;;;;;;;;;;;;
 1971_un_terror_convention_title;Ratify the 1971 UN Convention on Counter-Terrorism.;;;;;;;;x;;;;;;;;;;;;;


### PR DESCRIPTION
Whenever a terrorist attack happens and is not prevented (possibly TODO mechanic, for now only if hostages are rescued), the far-right will gain ground and demand changes. Whether the country accedes or not, the far right movement nationwide and in a couple of other countries with a free press will pick up, because it is reasonable to observe that terror attacks in other countries still scare people, especially in the West.

The changes are slight but frequent terror attacks will make them add up. Either way, for a brief period of time, the far right movement is brought into the national consciousness...

Fixes include scopes and insulating rich people from some of the chaos.