### PR TITLE
Prevent terrorism during decolonization

### DIFF
--- a/CWE/events/Terrorism.txt
+++ b/CWE/events/Terrorism.txt
@@ -251,6 +251,7 @@ province_event = {
 	trigger = {
 		owner = { NOT = { immigration_policy = nobody_gets_out } }
 		controlled_by_rebels = no
+		is_colonial = no
 		has_national_minority = yes
 		NOT = { has_province_modifier = terrorist_chaos }
 		NOT = { has_province_modifier = terror_strike_impending }
@@ -315,35 +316,35 @@ province_event = {
 
 		#Reduce based on year
 			modifier = { 
-			factor = 1.5
+			factor = 2
 			NOT = { year = 1950 }
 		}
 		modifier = { 
-			factor = 1.5
+			factor = 2
 			NOT = { year = 1960 }
 		}
 		modifier = { 
-			factor = 1.5
+			factor = 2
 			NOT = { year = 1970 }
 		}
 		modifier = { 
-			factor = 1.5
+			factor = 2
 			NOT = { year = 1980 }
 		}
 		modifier = { 
-			factor = 1.5
+			factor = 2
 			NOT = { year = 1990 }
 		}
 		modifier = { 
-			factor = 1.5
+			factor = 2
 			NOT = { year = 2000 }
 		}
 		modifier = { 
-			factor = 1.5
+			factor = 2
 			NOT = { year = 2010 }
 		}
 		modifier = { 
-			factor = 1.5
+			factor = 2
 			NOT = { year = 2020 }
 		}
 
@@ -377,8 +378,8 @@ province_event = {
 
 		#Increase - World tension
 		modifier = { 
-			factor = 0.5
-			owner = { has_country_modifier = war_on_terror }
+			factor = 2
+			NOT = { owner = { has_country_modifier = war_on_terror } }
 		}
 
 		modifier = { 


### PR DESCRIPTION
Starting a new game, terrorism events were more frequent than all other events, especially as a colonial power who already gets colonial unrest events. Although it is good to make them less frequent after a recent attack as in 040c049, it seems that there shouldn't be an attack during the 40s at all.

This also makes them half as frequent overall, in addition to year-based tweaks. Also prevents them for colonies.