### PR TITLE
Different newspaper titles for different countries

### DIFF
--- a/CWE/news/news_layout.txt
+++ b/CWE/news/news_layout.txt
@@ -1,0 +1,1769 @@
+#How much printing tension gives every type of news.
+#(if not specified on the list, default value is 1)
+article_tensions =
+{
+	PEACE_OFFER_ACCEPT = 100
+	GAME_EVENT = 30
+	PROVINCE_CHANGE_CONTROLLER = 5
+	PROVINCE_CHANGE_OWNER = 10
+	CONSTRUCTION_COMPLETE = 5
+	RESEARCH_COMPLETE = 2
+	BATTLE_OVER = 5
+	INVENTION = 2
+	REBEL_BREAK_COUNTRY = 100
+	NEW_PARTY = 10
+	WAR_DECLARED = 100
+	CRISIS_STARTED = 50
+	CRISIS_BACKER = 10
+	CRISIS_SIDE_JOINED = 10
+	CRISIS_RESOLVED = 50
+	DECISION = 30
+
+	# The following are ignored, as those are built on pre-printing stage.
+	#GOODS_PRICE_CHANGE = 0
+	#AI_AFRAID_OF = 0
+	#AI_LIKES_VERY_MUCH = 0
+}
+
+# News paper styles...
+style =
+{
+	name = "default_style"
+
+	# trigger that determines which newspaper style should use
+	trigger =
+	{
+		# player country scope trigger - called in moment of generating the newspaper
+	}
+
+	# Base window name
+	gui_window = "news_window_default"
+
+	# Big articles
+	article =
+	{
+		size = large
+		gui_window = "article_main"
+	}
+
+	# Medium articles
+	article =
+	{
+		size = medium
+		gui_window = "article_medium_1"
+	}
+	article =
+	{
+		size = medium
+		gui_window = "article_medium_2"
+	}
+
+	# Small articles
+	article =
+	{
+		size = small
+		gui_window = "article_small_1"
+	}
+	article =
+	{
+		size = small
+		gui_window = "article_small_2"
+	}
+	article =
+	{
+		size = small
+		gui_window = "article_small_3"
+	}
+	article =
+	{
+		size = small
+		gui_window = "article_small_4"
+	}
+	article =
+	{
+		size = small
+		gui_window = "article_small_5"
+	}
+
+	article_limits =
+	{
+		PEACE_OFFER_ACCEPT = 1
+		GAME_EVENT = 6
+		PROVINCE_CHANGE_CONTROLLER = 1
+		PROVINCE_CHANGE_OWNER = 1
+		CONSTRUCTION_COMPLETE = 1
+		RESEARCH_COMPLETE = 2
+		BATTLE_OVER = 3
+		INVENTION = 2
+		REBEL_BREAK_COUNTRY = 2
+		NEW_PARTY = 1
+		WAR_DECLARED = 2
+		CRISIS_STARTED = 1
+		CRISIS_BACKER = 2
+		CRISIS_SIDE_JOINED = 2
+		CRISIS_RESOLVED = 1
+		GOODS_PRICE_CHANGE = 1
+		AI_AFRAID_OF = 1
+		AI_LIKES_VERY_MUCH = 1
+		DECISION = 2
+		#FAKE = ? <- unused
+	}
+
+	# Title image - NOTE: higher titles take precedence, presumably
+	title_image =
+	{
+		# FRA ###################
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_french 
+						ruling_party_ideology = communist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_french 
+							ruling_party_ideology = communist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_french 
+							ruling_party_ideology = communist
+						}
+					}					
+				}
+			}
+			picture = "news/FRA_communist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_french 
+						ruling_party_ideology = populist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_french 
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_french 
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/FRA_facist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_french 
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_french 
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_french 
+							ruling_party_ideology = traditionalist
+						}
+					}					
+				}
+			}
+			picture = "news/FRA_reactionary_newspaper_title.dds"
+		}
+		
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_french 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_french 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_french 
+						}
+					}					
+				}
+			}
+			picture = "news/FRA_default_newspaper_title.dds"
+		}
+
+		# ENG ###################
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = british_cultures 
+						ruling_party_ideology = communist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = british_cultures 
+							ruling_party_ideology = communist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = british_cultures 
+							ruling_party_ideology = communist
+						}
+					}					
+				}
+			}
+			picture = "news/GBR_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = british_cultures 
+						ruling_party_ideology = populist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = british_cultures 
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = british_cultures 
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/GBR_facist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = british_cultures 
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = british_cultures 
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = british_cultures 
+							ruling_party_ideology = traditionalist
+						}
+					}					
+				}
+			}
+			picture = "news/GBR_reactionary_newspaper_title.dds"
+		}
+		
+		
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = british_cultures 
+						ruling_party_ideology = anarcho_liberal
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = british_cultures 
+							ruling_party_ideology = anarcho_liberal
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = british_cultures 
+							ruling_party_ideology = anarcho_liberal
+						}
+					}					
+				}
+			}
+			picture = "news/GBR_anarchoLiberal_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = british_cultures 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = british_cultures
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = british_cultures
+						}
+					}					
+				}
+			}
+			picture = "news/GBR_default_newspaper_title.dds"
+		}
+
+		
+		
+		# ITA ###################
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_italian 
+						ruling_party_ideology = communist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_italian 
+							ruling_party_ideology = communist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_italian 
+							ruling_party_ideology = communist
+						}
+					}					
+				}
+			}
+			picture = "news/ITA_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_italian 
+						ruling_party_ideology = populist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_italian 
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_italian 
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/ITA_facist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_italian 
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_italian 
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_italian 
+							ruling_party_ideology = traditionalist
+						}
+					}					
+				}
+			}
+			picture = "news/ITA_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_italian 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_italian 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_italian 
+						}
+					}					
+				}
+			}
+			picture = "news/ITA_default_newspaper_title.dds"
+		}
+		
+		# Greeks ###################
+		case =	{
+			trigger = { primary_culture = greek }
+			picture = "news/greek_newspaper_title.dds"
+		}
+
+		# TUR ###################
+		case =	{
+			trigger = { tag = TUR }
+			picture = "news/ottoman_newspaper_title.dds"
+		}
+
+		# RUS ###################
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_east_slavic 
+						ruling_party_ideology = communist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_east_slavic 
+							ruling_party_ideology = communist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_east_slavic 
+							ruling_party_ideology = communist
+						}
+					}					
+				}
+			}
+			picture = "news/RUS_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_east_slavic 
+						ruling_party_ideology = populist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_east_slavic 
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_east_slavic 
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/RUS_fascist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_east_slavic 
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_east_slavic 
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_east_slavic 
+							ruling_party_ideology = traditionalist
+						}
+					}					
+				}
+			}
+			picture = "news/RUS_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_east_slavic 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_east_slavic 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_east_slavic 
+						}
+					}					
+				}
+			}
+			picture = "news/RUS_default_newspaper_title.dds"
+		}
+
+		# POR ###################
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						tag = POR
+						ruling_party_ideology = communist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							tag = POR 
+							ruling_party_ideology = communist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							tag = POR 
+							ruling_party_ideology = communist 
+						}
+					}					
+				}
+			}
+			picture = "news/POR_communist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						tag = POR 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							tag = POR 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							tag = POR 
+						}
+					}					
+				}
+			}
+			picture = "news/POR_default_newspaper_title.dds"
+		}
+
+		# SPA ###################
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_spanish 
+						ruling_party_ideology = communist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_spanish 
+							ruling_party_ideology = communist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_spanish 
+							ruling_party_ideology = communist
+						}
+					}					
+				}
+			}
+			picture = "news/SPA_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_spanish 
+						ruling_party_ideology = populist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_spanish 
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_spanish 
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/SPA_facist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_spanish 
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_spanish 
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_spanish 
+							ruling_party_ideology = traditionalist
+						}
+					}					
+				}
+			}
+			picture = "news/SPA_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_spanish 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_spanish 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_spanish 
+						}
+					}					
+				}
+			}
+			picture = "news/SPA_default_newspaper_title.dds"
+		}
+		
+		# POL ###################
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						primary_culture = polish
+						ruling_party_ideology = communist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							primary_culture = polish 
+							ruling_party_ideology = communist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							primary_culture = polish
+							ruling_party_ideology = communist 
+						}
+					}					
+				}
+			}
+			picture = "news/POL_communist_newspaper_title.dds"
+		}
+		
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						primary_culture = polish
+						ruling_party_ideology = populist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							primary_culture = polish 
+							ruling_party_ideology = populist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							primary_culture = polish
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/POL_fascist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						primary_culture = polish
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							primary_culture = polish 
+							ruling_party_ideology = traditionalist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							primary_culture = polish
+							ruling_party_ideology = traditionalist 
+						}
+					}					
+				}
+			}
+			picture = "news/POL_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						primary_culture = polish
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							primary_culture = polish 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							primary_culture = polish
+						}
+					}					
+				}
+			}
+			picture = "news/POL_default_newspaper_title.dds"
+		}
+
+		# USA ###################
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+						ruling_party_ideology = populist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/USA_facist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+							ruling_party_ideology = traditionalist
+						}
+					}					
+				}
+			}
+			picture = "news/USA_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							or = {
+							tag = USA
+							tag = CSA
+							tag = TEX
+							tag = CAL
+							tag = HAW
+						}
+						}
+					}
+				}
+			}
+			picture = "news/USA_default_newspaper_title.dds"
+		}
+
+		# BRZ ###################
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						tag = BRZ
+						ruling_party_ideology = communist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							tag = BRZ 
+							ruling_party_ideology = communist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							tag = BRZ
+							ruling_party_ideology = communist 
+						}
+					}					
+				}
+			}
+			picture = "news/BRZ_communist_newspaper_title.dds"
+		}
+		
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						tag = BRZ
+						ruling_party_ideology = populist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							tag = BRZ 
+							ruling_party_ideology = populist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							tag = BRZ
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/BRZ_fascist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						tag = BRZ
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							tag = BRZ 
+							ruling_party_ideology = traditionalist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							tag = BRZ
+							ruling_party_ideology = traditionalist 
+						}
+					}					
+				}
+			}
+			picture = "news/BRZ_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						tag = BRZ
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							tag = BRZ 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							tag = BRZ
+						}
+					}					
+				}
+			}
+			picture = "news/BRZ_default_newspaper_title.dds"
+		}
+		
+		# Spanish Latin America ###################
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = latin_american_cultures
+						ruling_party_ideology = communist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = latin_american_cultures 
+							ruling_party_ideology = communist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = latin_american_cultures
+							ruling_party_ideology = communist 
+						}
+					}					
+				}
+			}
+			picture = "news/latinamerica_communist_newspaper_title.dds"
+		}
+		
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = latin_american_cultures
+						ruling_party_ideology = populist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = latin_american_cultures 
+							ruling_party_ideology = populist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = latin_american_cultures
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/latinamerica_fascist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = latin_american_cultures
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = latin_american_cultures 
+							ruling_party_ideology = traditionalist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = latin_american_cultures
+							ruling_party_ideology = traditionalist 
+						}
+					}					
+				}
+			}
+			picture = "news/latinamerica_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = latin_american_cultures
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = latin_american_cultures 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = latin_american_cultures
+						}
+					}					
+				}
+			}
+			picture = "news/latinamerica_default_newspaper_title.dds"
+		}
+
+				# Korea ###################
+
+		case =	{
+			trigger = { and = { primary_culture = korean not = { ruling_party_ideology = communist } } }
+			picture = "news/KOR_default_newspaper_title.dds"
+		}
+
+
+				# JAP ###################
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = far_east_asian not = { primary_culture = korean }
+						ruling_party_ideology = communist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = far_east_asian not = { primary_culture = korean } 
+							ruling_party_ideology = communist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							ruling_party_ideology = communist 
+						}
+					}					
+				}
+			}
+			picture = "news/JAP_communist_newspaper_title.dds"
+		}
+		
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = far_east_asian not = { primary_culture = korean }
+						ruling_party_ideology = populist 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = far_east_asian not = { primary_culture = korean } 
+							ruling_party_ideology = populist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/JAP_fascist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = far_east_asian not = { primary_culture = korean }
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							ruling_party_ideology = traditionalist 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							ruling_party_ideology = traditionalist 
+						}
+					}					
+				}
+			}
+			picture = "news/JAP_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = far_east_asian not = { primary_culture = korean }
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = far_east_asian not = { primary_culture = korean } 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+						}
+					}					
+				}
+			}
+			picture = "news/JAP_default_newspaper_title.dds"
+		}
+		
+		# Arab ##########################
+		case =	{
+			trigger = {
+				or = {
+					is_culture_group = arabic
+					is_culture_group = maghreb_cultures
+				}
+			}
+			picture = "news/arabic_newspaper_title.dds"
+		}
+
+		# AUS and KUK ###################
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						OR = {
+							tag = AUS
+							#tag = KUK
+							#tag = DNB
+						}
+						ruling_party_ideology = communist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							OR = {
+								tag = AUS
+								#tag = KUK
+								#tag = DNB
+							}
+							ruling_party_ideology = communist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							OR = {
+								tag = AUS
+								#tag = KUK
+								#tag = DNB
+							}
+							ruling_party_ideology = communist
+						}
+					}					
+				}
+			}
+			picture = "news/AUS_communist_newspaper_title.dds"
+		}
+		
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						OR = {
+							tag = AUS
+							#tag = KUK
+							#tag = DNB
+						}
+						ruling_party_ideology = populist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							OR = {
+								tag = AUS
+								#tag = KUK
+								#tag = DNB
+							}
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							OR = {
+								tag = AUS
+								#tag = KUK
+								#tag = DNB
+							}
+							ruling_party_ideology = populist
+						}
+					}					
+				}
+			}
+			picture = "news/AUS_fascist_newspaper_title.dds"
+		}
+		
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						OR = {
+							tag = AUS
+							#tag = KUK
+							#tag = DNB
+						}
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							OR = {
+								tag = AUS
+								#tag = KUK
+								#tag = DNB
+							}
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							OR = {
+								tag = AUS
+								#tag = KUK
+								#tag = DNB
+							}
+							ruling_party_ideology = traditionalist
+						}
+					}					
+				}
+			}
+			picture = "news/AUS_reactionary_newspaper_title.dds"
+		}
+		
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						OR = {
+							tag = AUS
+							#tag = KUK
+							#tag = DNB
+						}
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							OR = {
+								tag = AUS
+								#tag = KUK
+								#tag = DNB
+							}
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							OR = {
+								tag = AUS
+								#tag = KUK
+								#tag = DNB
+							}
+						}
+					}					
+				}
+			}
+			picture = "news/AUS_default_newspaper_title.dds"
+		}
+
+		# Germanic ###################
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_germanic_cultures 
+						ruling_party_ideology = traditionalist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_germanic_cultures 
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_germanic_cultures 
+							ruling_party_ideology = traditionalist
+						}
+					}					
+				}
+			}
+			picture = "news/GER_reactionary_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_germanic_cultures 
+						ruling_party_ideology = communist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_germanic_cultures 
+							ruling_party_ideology = communist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_germanic_cultures 
+							ruling_party_ideology = communist
+						}
+					}					
+				}
+			}
+			picture = "news/GER_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = { 
+				or = {
+					and = {
+						OR = {
+							primary_culture = north_german
+							primary_culture = south_german
+						}
+						ruling_party_ideology = populist
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							OR = {
+								primary_culture = north_german
+								primary_culture = south_german
+							}
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							OR = {
+								primary_culture = north_german
+								primary_culture = south_german
+							}
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/GER_facist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { 
+				or = {
+					and = {
+						is_culture_group = european_germanic_cultures 
+					}
+					and = {
+						civilized = no
+						part_of_sphere = yes
+
+						sphere_owner = {
+							is_culture_group = european_germanic_cultures 
+						}
+					}
+					and = {
+						civilized = no
+						is_vassal = yes
+
+						overlord = {
+							is_culture_group = european_germanic_cultures 
+						}
+					}					
+				}
+			}
+			picture = "news/GER_default_newspaper_title.dds"
+		}
+
+
+		# Ruling ideology generics ########
+		case =	{
+			trigger = { ruling_party_ideology = anarcho_liberal }
+			picture = "news/anarchoLiberal_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { ruling_party_ideology = communist }
+			picture = "news/communist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { ruling_party_ideology = populist }
+			picture = "news/facist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = { ruling_party_ideology = traditionalist }
+			picture = "news/reactionary_newspaper_title.dds"
+		}
+
+		#TODO: add ARG, ATJ, CHI, IND, ISR, PER, QUE, SAF, SER, SIA, SWI, TAI, TUR (differs from Ottoman)
+		#Replace uncivilized with some other method of newspaper distribution
+
+		# Fallback picture
+		case = { 
+			picture = "news/generic_newspaper_title.dds" 
+		}
+	}
+}


### PR DESCRIPTION
There are a lot of newspaper titles in the pictures, but none of them are being used. I took the news files for vanilla and adapted them to work with the mod. Some work still needs to be done. For example, not all of the images present in the mod are from vanilla countries; there are extra ones, listed at the bottom of the file, that need to be added.
  Additionally, vanilla counts on uncivs using the newspapers of their sphere leaders. This will have to be replaced; I suggest simply the sphere leader, as it would provide a cool, more visible effect. It can be arranged so that a country's own newspapers take precedence; this is only for those without it.
  Finally, there are images for countries with an anarcho_liberal ruling government. I'm not sure what the equivalent would be in the mod; I don't think there is one. Those can be kept for a future ideology, such as libertarianism, or removed.