### PR TITLE
Newspaper overhaul complete

### DIFF
--- a/CWE/news/news_layout.txt
+++ b/CWE/news/news_layout.txt
@@ -109,522 +109,242 @@ style =
 		#FAKE = ? <- unused
 	}
 
-	# Title image - NOTE: higher titles take precedence, presumably
+	# Title image - NOTE: higher titles take precedence
 	title_image =
 	{
+
+		#########################
+		# OWN NEWSPAPER
+		#########################
+
+		# Quebec and Miquelon ###
+		# TODO: add nationalist
+		case = {
+			trigger = {
+				and = {
+					capital_scope = { continent = north_america }
+					is_culture_group = european_french
+					not = { ruling_party_ideology = nationalist }
+				}
+			}
+			picture = "news/QUE_procanada_newspaper_title.dds"
+		}
 		# FRA ###################
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_french 
+			trigger = {
+				and = {
+					is_culture_group = european_french
+					or = {
 						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_french 
-							ruling_party_ideology = communist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_french 
-							ruling_party_ideology = communist
-						}
-					}					
 				}
 			}
 			picture = "news/FRA_communist_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_french 
-						ruling_party_ideology = populist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_french 
-							ruling_party_ideology = populist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_french 
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = european_french
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/FRA_facist_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_french 
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_french 
-							ruling_party_ideology = traditionalist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_french 
-							ruling_party_ideology = traditionalist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = european_french
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/FRA_reactionary_newspaper_title.dds"
 		}
-		
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_french 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_french 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_french 
-						}
-					}					
-				}
+			trigger = {
+				is_culture_group = european_french
 			}
 			picture = "news/FRA_default_newspaper_title.dds"
 		}
 
 		# ENG ###################
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = british_cultures 
+			trigger = {
+				and = {
+					is_culture_group = british_cultures
+					or = {
 						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = british_cultures 
-							ruling_party_ideology = communist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = british_cultures 
-							ruling_party_ideology = communist
-						}
-					}					
 				}
 			}
 			picture = "news/GBR_communist_newspaper_title.dds"
+			# Missing TODO add
 		}
 
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = british_cultures 
-						ruling_party_ideology = populist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = british_cultures 
-							ruling_party_ideology = populist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = british_cultures 
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = british_cultures
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/GBR_facist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = british_cultures 
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = british_cultures 
-							ruling_party_ideology = traditionalist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = british_cultures 
-							ruling_party_ideology = traditionalist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = british_cultures
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/GBR_reactionary_newspaper_title.dds"
 		}
-		
-		
+
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = british_cultures 
-						ruling_party_ideology = anarcho_liberal
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = british_cultures 
-							ruling_party_ideology = anarcho_liberal
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = british_cultures 
-							ruling_party_ideology = anarcho_liberal
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = british_cultures
+					ruling_party_ideology = liberal
 				}
 			}
 			picture = "news/GBR_anarchoLiberal_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = british_cultures 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = british_cultures
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = british_cultures
-						}
-					}					
-				}
+			trigger = {
+				is_culture_group = british_cultures
 			}
 			picture = "news/GBR_default_newspaper_title.dds"
 		}
 
-		
-		
+
 		# ITA ###################
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_italian 
+			trigger = {
+				and = {
+					is_culture_group = european_italian
+					or = {
 						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_italian 
-							ruling_party_ideology = communist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_italian 
-							ruling_party_ideology = communist
-						}
-					}					
 				}
 			}
 			picture = "news/ITA_communist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_italian 
-						ruling_party_ideology = populist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_italian 
-							ruling_party_ideology = populist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_italian 
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = european_italian
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/ITA_facist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_italian 
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_italian 
-							ruling_party_ideology = traditionalist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_italian 
-							ruling_party_ideology = traditionalist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = european_italian
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/ITA_reactionary_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_italian 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_italian 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_italian 
-						}
-					}					
-				}
+			trigger = {
+				is_culture_group = european_italian
 			}
 			picture = "news/ITA_default_newspaper_title.dds"
 		}
-		
-		# Greeks ###################
+		# Greeks ########################
 		case =	{
 			trigger = { primary_culture = greek }
 			picture = "news/greek_newspaper_title.dds"
 		}
 
-		# TUR ###################
+		# Cyrillic Yugoslav #############
+		case = {
+			trigger = {
+				or = {
+					primary_culture = yugoslav
+					primary_culture = serb
+					primary_culture = bulgarian
+				}
+			}
+			picture = "news/SER_default_newspaper_title.dds"
+		}
+
+		# TUR ###########################
+		case =	{
+			trigger = {
+				and = {
+					tag = TUR
+					ruling_party_ideology = traditionalist
+				}
+			}
+			picture = "news/TUR_reactionary_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				and = {
+					tag = TUR
+					or = {
+						government = democracy
+						government = democracy1
+						government = socialist_democracy
+					}
+				}
+			}
+			picture = "news/TUR_default_newspaper_title.dds"
+		}
 		case =	{
 			trigger = { tag = TUR }
 			picture = "news/ottoman_newspaper_title.dds"
 		}
 
-		# RUS ###################
+		# RUS ###########################
 		case = {
-			trigger = { 
-				or = {
+			trigger = {
 					and = {
-						is_culture_group = european_east_slavic 
-						ruling_party_ideology = communist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_east_slavic 
+						is_culture_group = european_east_slavic
+						or = {
 							ruling_party_ideology = communist
+							ruling_party_ideology = communist_social
 						}
 					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_east_slavic 
-							ruling_party_ideology = communist
-						}
-					}					
-				}
 			}
 			picture = "news/RUS_communist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
+			trigger = {
 					and = {
-						is_culture_group = european_east_slavic 
+						is_culture_group = european_east_slavic
 						ruling_party_ideology = populist
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_east_slavic 
-							ruling_party_ideology = populist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_east_slavic 
-							ruling_party_ideology = populist
-						}
-					}					
-				}
 			}
 			picture = "news/RUS_fascist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
+			trigger = {
 					and = {
-						is_culture_group = european_east_slavic 
+						is_culture_group = european_east_slavic
 						ruling_party_ideology = traditionalist
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_east_slavic 
-							ruling_party_ideology = traditionalist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_east_slavic 
-							ruling_party_ideology = traditionalist
-						}
-					}					
-				}
 			}
 			picture = "news/RUS_reactionary_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_east_slavic 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_east_slavic 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_east_slavic 
-						}
-					}					
-				}
+			trigger = {
+				is_culture_group = european_east_slavic
 			}
 			picture = "news/RUS_default_newspaper_title.dds"
 		}
@@ -632,303 +352,109 @@ style =
 		# POR ###################
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						tag = POR
-						ruling_party_ideology = communist 
+			trigger = {
+				and = {
+					tag = POR
+					or = {
+						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							tag = POR 
-							ruling_party_ideology = communist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							tag = POR 
-							ruling_party_ideology = communist 
-						}
-					}					
 				}
 			}
 			picture = "news/POR_communist_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						tag = POR 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							tag = POR 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							tag = POR 
-						}
-					}					
-				}
+			trigger = {
+				tag = POR
 			}
 			picture = "news/POR_default_newspaper_title.dds"
 		}
 
 		# SPA ###################
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_spanish 
+			trigger = {
+				and = {
+					is_culture_group = european_spanish
+					or = {
 						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_spanish 
-							ruling_party_ideology = communist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_spanish 
-							ruling_party_ideology = communist
-						}
-					}					
 				}
 			}
 			picture = "news/SPA_communist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_spanish 
-						ruling_party_ideology = populist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_spanish 
-							ruling_party_ideology = populist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_spanish 
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = european_spanish
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/SPA_facist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_spanish 
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_spanish 
-							ruling_party_ideology = traditionalist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_spanish 
-							ruling_party_ideology = traditionalist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = european_spanish
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/SPA_reactionary_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_spanish 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_spanish 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_spanish 
-						}
-					}					
-				}
+			trigger = {
+				is_culture_group = european_spanish
 			}
 			picture = "news/SPA_default_newspaper_title.dds"
 		}
-		
+
 		# POL ###################
-
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						primary_culture = polish
-						ruling_party_ideology = communist 
+			trigger = {
+				and = {
+					primary_culture = polish
+					or = {
+						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							primary_culture = polish 
-							ruling_party_ideology = communist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							primary_culture = polish
-							ruling_party_ideology = communist 
-						}
-					}					
 				}
 			}
 			picture = "news/POL_communist_newspaper_title.dds"
 		}
-		
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						primary_culture = polish
-						ruling_party_ideology = populist 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							primary_culture = polish 
-							ruling_party_ideology = populist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							primary_culture = polish
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					primary_culture = polish
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/POL_fascist_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						primary_culture = polish
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							primary_culture = polish 
-							ruling_party_ideology = traditionalist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							primary_culture = polish
-							ruling_party_ideology = traditionalist 
-						}
-					}					
+			trigger = {
+				and = {
+					primary_culture = polish
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/POL_reactionary_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						primary_culture = polish
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							primary_culture = polish 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							primary_culture = polish
-						}
-					}					
-				}
+			trigger = {
+				primary_culture = polish
 			}
 			picture = "news/POL_default_newspaper_title.dds"
 		}
 
 		# USA ###################
 		case = {
-			trigger = { 
-				or = {
+			trigger = {
 					and = {
 						or = {
 							tag = USA
@@ -939,129 +465,34 @@ style =
 						}
 						ruling_party_ideology = populist
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							or = {
-							tag = USA
-							tag = CSA
-							tag = TEX
-							tag = CAL
-							tag = HAW
-						}
-							ruling_party_ideology = populist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							or = {
-							tag = USA
-							tag = CSA
-							tag = TEX
-							tag = CAL
-							tag = HAW
-						}
-							ruling_party_ideology = populist
-						}
-					}					
 				}
-			}
 			picture = "news/USA_facist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						or = {
-							tag = USA
-							tag = CSA
-							tag = TEX
-							tag = CAL
-							tag = HAW
-						}
-						ruling_party_ideology = traditionalist
+			trigger = {
+				and = {
+					or = {
+						tag = USA
+						tag = CSA
+						tag = TEX
+						tag = CAL
+						tag = HAW
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							or = {
-							tag = USA
-							tag = CSA
-							tag = TEX
-							tag = CAL
-							tag = HAW
-						}
-							ruling_party_ideology = traditionalist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							or = {
-							tag = USA
-							tag = CSA
-							tag = TEX
-							tag = CAL
-							tag = HAW
-						}
-							ruling_party_ideology = traditionalist
-						}
-					}					
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/USA_reactionary_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
+			trigger = {
 				or = {
-					and = {
-						or = {
-							tag = USA
-							tag = CSA
-							tag = TEX
-							tag = CAL
-							tag = HAW
-						}
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							or = {
-							tag = USA
-							tag = CSA
-							tag = TEX
-							tag = CAL
-							tag = HAW
-						}
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							or = {
-							tag = USA
-							tag = CSA
-							tag = TEX
-							tag = CAL
-							tag = HAW
-						}
-						}
-					}
+					tag = USA
+					tag = CSA
+					tag = TEX
+					tag = CAL
+					tag = HAW
 				}
 			}
 			picture = "news/USA_default_newspaper_title.dds"
@@ -1070,368 +501,274 @@ style =
 		# BRZ ###################
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						tag = BRZ
-						ruling_party_ideology = communist 
+			trigger = {
+				and = {
+					tag = BRZ
+					or = {
+						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							tag = BRZ 
-							ruling_party_ideology = communist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							tag = BRZ
-							ruling_party_ideology = communist 
-						}
-					}					
 				}
 			}
 			picture = "news/BRZ_communist_newspaper_title.dds"
 		}
-		
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						tag = BRZ
-						ruling_party_ideology = populist 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							tag = BRZ 
-							ruling_party_ideology = populist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							tag = BRZ
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					tag = BRZ
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/BRZ_fascist_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						tag = BRZ
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							tag = BRZ 
-							ruling_party_ideology = traditionalist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							tag = BRZ
-							ruling_party_ideology = traditionalist 
-						}
-					}					
+			trigger = {
+				and = {
+					tag = BRZ
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/BRZ_reactionary_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						tag = BRZ
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							tag = BRZ 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							tag = BRZ
-						}
-					}					
-				}
+			trigger = {
+				tag = BRZ
 			}
 			picture = "news/BRZ_default_newspaper_title.dds"
 		}
-		
-		# Spanish Latin America ###################
+
+		# Spanish Latin America Nations ###########
+
+		# TODO: Use capital province id, to keep newspaper after forming union and not become generic
+		case =	{
+			trigger = { tag = ARG }
+			picture = "news/ARG_default_newspaper_title.dds"
+		}
+
+		# Spanish Latin America Generic ###########
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = latin_american_cultures
-						ruling_party_ideology = communist 
+			trigger = {
+				and = {
+					is_culture_group = latin_american_cultures
+					or = {
+						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = latin_american_cultures 
-							ruling_party_ideology = communist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = latin_american_cultures
-							ruling_party_ideology = communist 
-						}
-					}					
 				}
 			}
 			picture = "news/latinamerica_communist_newspaper_title.dds"
 		}
-		
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = latin_american_cultures
-						ruling_party_ideology = populist 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = latin_american_cultures 
-							ruling_party_ideology = populist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = latin_american_cultures
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = latin_american_cultures
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/latinamerica_fascist_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = latin_american_cultures
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = latin_american_cultures 
-							ruling_party_ideology = traditionalist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = latin_american_cultures
-							ruling_party_ideology = traditionalist 
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = latin_american_cultures
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/latinamerica_reactionary_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = latin_american_cultures
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = latin_american_cultures 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = latin_american_cultures
-						}
-					}					
-				}
+			trigger = {
+				is_culture_group = latin_american_cultures
 			}
 			picture = "news/latinamerica_default_newspaper_title.dds"
 		}
 
-				# Korea ###################
-
+		# Korea #########################
+		# TODO: add DPRK paper
 		case =	{
-			trigger = { and = { primary_culture = korean not = { ruling_party_ideology = communist } } }
+			trigger = { and = {
+				primary_culture = korean
+				not = { ruling_party_ideology = communist }
+				not = { ruling_party_ideology = communist_social }
+			} }
 			picture = "news/KOR_default_newspaper_title.dds"
 		}
 
 
-				# JAP ###################
+		# JAP ###########################
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = far_east_asian not = { primary_culture = korean }
-						ruling_party_ideology = communist 
+			trigger = {
+				and = {
+					is_culture_group = far_east_asian not = { primary_culture = korean }
+					or = {
+						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = far_east_asian not = { primary_culture = korean } 
-							ruling_party_ideology = communist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = far_east_asian not = { primary_culture = korean }
-							ruling_party_ideology = communist 
-						}
-					}					
 				}
 			}
 			picture = "news/JAP_communist_newspaper_title.dds"
 		}
-		
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = far_east_asian not = { primary_culture = korean }
-						ruling_party_ideology = populist 
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = far_east_asian not = { primary_culture = korean } 
-							ruling_party_ideology = populist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = far_east_asian not = { primary_culture = korean }
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = far_east_asian not = { primary_culture = korean }
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/JAP_fascist_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = far_east_asian not = { primary_culture = korean }
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = far_east_asian not = { primary_culture = korean }
-							ruling_party_ideology = traditionalist 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = far_east_asian not = { primary_culture = korean }
-							ruling_party_ideology = traditionalist 
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = far_east_asian not = { primary_culture = korean }
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/JAP_reactionary_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = far_east_asian not = { primary_culture = korean }
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = far_east_asian not = { primary_culture = korean } 
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = far_east_asian not = { primary_culture = korean }
-						}
-					}					
+			trigger = {
+				and = {
+					is_culture_group = far_east_asian not = { primary_culture = korean }
 				}
 			}
 			picture = "news/JAP_default_newspaper_title.dds"
 		}
-		
+
+		# Chinese #######################
+		# Pro-China and anti-China don't really translate into ideologies
+		# Note this would also include Singapore
+		case = {
+			trigger = {
+				and = {
+					is_culture_group = east_asian
+					or = {
+						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
+					}
+				}
+			}
+			picture = "news/CHI_communist_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				and = {
+					is_culture_group = east_asian
+					or = {
+						ruling_party_ideology = liberal
+						ruling_party_ideology = progressive
+					}
+				}
+			}
+			picture = "news/TAI_antichina_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				and = {
+					is_culture_group = east_asian
+					ruling_party_ideology = socialist
+				}
+			}
+			picture = "news/TAI_prochina_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				is_culture_group = east_asian
+			}
+			picture = "news/TAI_default_newspaper_title.dds"
+		}
+
+		# Atjeh #########################
+		# Note: for now applying to all Latin alphabet SEA
+		case = {
+			trigger = {
+				or = {
+					primary_culture = ache
+					primary_culture = indonesian
+					primary_culture = malay
+				}
+			}
+			picture = "news/ATJ_default_newspaper_title.dds"
+		}
+
+		# India #########################
+		case = {
+			trigger = {
+				and = {
+					or = {
+						is_culture_group = south_asian_indian
+						is_culture_group = south_asian
+					}
+					or = {
+						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
+					}
+				}
+			}
+			picture = "news/IND_communist_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				and = {
+					or = {
+						is_culture_group = south_asian_indian
+						is_culture_group = south_asian
+					}
+					or = {
+						ruling_party_ideology = conservative
+						ruling_party_ideology = big_tent
+					}
+				}
+			}
+			picture = "news/IND_conservative_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				and = {
+					or = {
+						is_culture_group = south_asian_indian
+						is_culture_group = south_asian
+					}
+					ruling_party_ideology = populist
+				}
+			}
+			picture = "news/IND_fascist_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					is_culture_group = south_asian_indian
+					is_culture_group = south_asian
+				}
+			}
+			picture = "news/IND_default_newspaper_title.dds"
+		}
+
+		# Israel ########################
+		case = {
+			trigger = {
+				is_culture_group = jewish_cultures
+			}
+			picture = "news/ISR_default_newspaper_title.dds"
+		}
+
+		# Egypt #########################
+		case =	{
+			trigger = {
+				capital = 1745 # Cairo
+				ruling_party_ideology = traditionalist
+			}
+			picture = "news/EGY_reactionary_newspaper_title.dds"
+		}
+
 		# Arab ##########################
 		case =	{
 			trigger = {
@@ -1442,265 +779,1762 @@ style =
 			}
 			picture = "news/arabic_newspaper_title.dds"
 		}
+		# Persia ########################
+		# TODO: Consider using for Pakistan?
+		case = {
+			trigger = {
+				and = {
+					is_culture_group = iranian_turanian
+					ruling_party_ideology = traditionalist
+				}
+			}
+			picture = "news/PER_reactionary_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				is_culture_group = iranian_turanian
+			}
+			picture = "news/PER_default_newspaper_title.dds"
+		}
+
+		# SAF & Bantustans ##############
+		case = {
+			trigger = {
+				or = {
+					tag = SAF
+					primary_culture = afrikaaner
+					primary_culture = coloured
+				}
+			}
+			picture = "news/SAF_default_newspaper_title.dds"
+		}
 
 		# AUS and KUK ###################
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						OR = {
-							tag = AUS
-							#tag = KUK
-							#tag = DNB
-						}
+			trigger = {
+				and = {
+					tag = AUS
+					or = {
 						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							OR = {
-								tag = AUS
-								#tag = KUK
-								#tag = DNB
-							}
-							ruling_party_ideology = communist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							OR = {
-								tag = AUS
-								#tag = KUK
-								#tag = DNB
-							}
-							ruling_party_ideology = communist
-						}
-					}					
 				}
 			}
 			picture = "news/AUS_communist_newspaper_title.dds"
 		}
-		
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						OR = {
-							tag = AUS
-							#tag = KUK
-							#tag = DNB
-						}
-						ruling_party_ideology = populist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							OR = {
-								tag = AUS
-								#tag = KUK
-								#tag = DNB
-							}
-							ruling_party_ideology = populist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							OR = {
-								tag = AUS
-								#tag = KUK
-								#tag = DNB
-							}
-							ruling_party_ideology = populist
-						}
-					}					
+			trigger = {
+				and = {
+					tag = AUS
+					ruling_party_ideology = populist
 				}
 			}
 			picture = "news/AUS_fascist_newspaper_title.dds"
 		}
-		
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						OR = {
-							tag = AUS
-							#tag = KUK
-							#tag = DNB
-						}
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							OR = {
-								tag = AUS
-								#tag = KUK
-								#tag = DNB
-							}
-							ruling_party_ideology = traditionalist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							OR = {
-								tag = AUS
-								#tag = KUK
-								#tag = DNB
-							}
-							ruling_party_ideology = traditionalist
-						}
-					}					
+			trigger = {
+				and = {
+					tag = AUS
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/AUS_reactionary_newspaper_title.dds"
 		}
-		
 		case =	{
-			trigger = { 
-				or = {
-					and = {
-						OR = {
-							tag = AUS
-							#tag = KUK
-							#tag = DNB
-						}
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							OR = {
-								tag = AUS
-								#tag = KUK
-								#tag = DNB
-							}
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							OR = {
-								tag = AUS
-								#tag = KUK
-								#tag = DNB
-							}
-						}
-					}					
-				}
+			trigger = {
+				tag = AUS
 			}
 			picture = "news/AUS_default_newspaper_title.dds"
 		}
 
-		# Germanic ###################
+		# SWI ########################
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_germanic_cultures 
-						ruling_party_ideology = traditionalist
-					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
+			trigger = { tag = SWI }
+			picture = "news/SWI_default_newspaper_title.dds"
+		}
 
-						sphere_owner = {
-							is_culture_group = european_germanic_cultures 
-							ruling_party_ideology = traditionalist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_germanic_cultures 
-							ruling_party_ideology = traditionalist
-						}
-					}					
+		# Germanic ###################
+		# Germany, GDR, Lux, minors
+		case = {
+			trigger = {
+				and = {
+					is_culture_group = european_germanic_cultures
+					ruling_party_ideology = traditionalist
 				}
 			}
 			picture = "news/GER_reactionary_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
-				or = {
-					and = {
-						is_culture_group = european_germanic_cultures 
+			trigger = {
+				and = {
+					is_culture_group = european_germanic_cultures
+					or = {
 						ruling_party_ideology = communist
+						ruling_party_ideology = communist_social
 					}
-					and = {
-						civilized = no
-						part_of_sphere = yes
-
-						sphere_owner = {
-							is_culture_group = european_germanic_cultures 
-							ruling_party_ideology = communist
-						}
-					}
-					and = {
-						civilized = no
-						is_vassal = yes
-
-						overlord = {
-							is_culture_group = european_germanic_cultures 
-							ruling_party_ideology = communist
-						}
-					}					
 				}
 			}
 			picture = "news/GER_communist_newspaper_title.dds"
 		}
 
 		case = {
-			trigger = { 
+			trigger = {
+				and = {
+					is_culture_group = european_germanic_cultures
+					ruling_party_ideology = populist
+				}
+			}
+			picture = "news/GER_facist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
 				or = {
 					and = {
-						OR = {
-							primary_culture = north_german
-							primary_culture = south_german
-						}
-						ruling_party_ideology = populist
+						is_culture_group = european_germanic_cultures
 					}
 					and = {
-						civilized = no
 						part_of_sphere = yes
-
 						sphere_owner = {
-							OR = {
-								primary_culture = north_german
-								primary_culture = south_german
+							is_culture_group = european_germanic_cultures
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_germanic_cultures
+						}
+					}
+				}
+			}
+			picture = "news/GER_default_newspaper_title.dds"
+		}
+
+
+		#########################
+		# OVERLORD NEWSPAPER
+		# There are 3 sphere newspapers currently,
+		# otherwise will use same paper as overlord
+		#########################
+
+		# RUS ###################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_east_slavic
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
 							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_east_slavic
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/RUS_communist_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_east_slavic
+							not = { or = {
+							ruling_party_ideology = communist
+							ruling_party_ideology = communist_social
+						} }
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_east_slavic
+							not = { or = {
+							ruling_party_ideology = communist
+							ruling_party_ideology = communist_social
+						} }
+						}
+					}
+				}
+			}
+			picture = "news/RUS_sphere_newspaper_title.dds"
+		}
+
+		# USA ###################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							or = {
+								tag = USA
+								tag = CSA
+								tag = TEX
+								tag = CAL
+								tag = HAW
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							or = {
+								tag = USA
+								tag = CSA
+								tag = TEX
+								tag = CAL
+								tag = HAW
+							}
+						}
+					}
+				}
+			}
+			picture = "news/USA_sphere_newspaper_title.dds"
+		}
+
+		# Persia ########################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = iranian_turanian
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = iranian_turanian
+						}
+					}
+				}
+			}
+			picture = "news/PER_sphere_newspaper_title.dds"
+		}
+
+		# FRA ###################
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_french
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_french
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/FRA_communist_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_french
 							ruling_party_ideology = populist
 						}
 					}
 					and = {
-						civilized = no
 						is_vassal = yes
-
 						overlord = {
-							OR = {
-								primary_culture = north_german
-								primary_culture = south_german
+							is_culture_group = european_french
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/FRA_facist_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_french
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_french
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/FRA_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_french
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_french
+						}
+					}
+				}
+			}
+			picture = "news/FRA_default_newspaper_title.dds"
+		}
+
+		# ENG ###################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = british_cultures
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
 							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = british_cultures
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/GBR_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = british_cultures
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = british_cultures
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/GBR_facist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = british_cultures
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = british_cultures
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/GBR_reactionary_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = british_cultures
+							ruling_party_ideology = liberal
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = british_cultures
+							ruling_party_ideology = liberal
+						}
+					}
+				}
+			}
+			picture = "news/GBR_anarchoLiberal_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = british_cultures
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = british_cultures
+						}
+					}
+				}
+			}
+			picture = "news/GBR_default_newspaper_title.dds"
+		}
+
+		# ITA ###################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_italian
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_italian
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/ITA_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_italian
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_italian
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/ITA_facist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_italian
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_italian
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/ITA_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_italian
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_italian
+						}
+					}
+				}
+			}
+			picture = "news/ITA_default_newspaper_title.dds"
+		}
+
+		# Greeks ########################
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { primary_culture = greek }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { primary_culture = greek }
+					}
+				}
+			}
+			picture = "news/greek_newspaper_title.dds"
+		}
+		
+
+		# Cyrillic Yugoslav #############
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							or = {
+								primary_culture = yugoslav
+								primary_culture = serb
+								primary_culture = bulgarian
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							or = {
+								primary_culture = yugoslav
+								primary_culture = serb
+								primary_culture = bulgarian
+							}
+						}
+					}
+				}
+			}
+			picture = "news/SER_default_newspaper_title.dds"
+		}
+
+		# TUR ###########################
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { and = {
+							tag = TUR
+							ruling_party_ideology = traditionalist
+						} }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { and = {
+							tag = TUR
+							ruling_party_ideology = traditionalist
+						} }
+					}
+				}
+			}
+			picture = "news/TUR_reactionary_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { and = {
+							tag = TUR
+							or = {
+								government = democracy
+								government = democracy1
+								government = socialist_democracy
+							}
+						} }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { and = {
+							tag = TUR
+							or = {
+								government = democracy
+								government = democracy1
+								government = socialist_democracy
+							}
+						} }
+					}
+				}
+			}
+			picture = "news/TUR_default_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { tag = TUR }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { tag = TUR }
+					}
+				}
+			}
+			picture = "news/ottoman_newspaper_title.dds"
+		}
+
+		# POR ###################
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = POR
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = POR
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/POR_communist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = POR
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = POR
+						}
+					}
+				}
+			}
+			picture = "news/POR_default_newspaper_title.dds"
+		}
+
+		# SPA ###################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_spanish
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_spanish
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/SPA_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_spanish
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_spanish
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/SPA_facist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_spanish
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_spanish
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/SPA_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_spanish
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_spanish
+						}
+					}
+				}
+			}
+			picture = "news/SPA_default_newspaper_title.dds"
+		}
+
+		# POL ###################
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							primary_culture = polish
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							primary_culture = polish
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/POL_communist_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							primary_culture = polish
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							primary_culture = polish
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/POL_fascist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							primary_culture = polish
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							primary_culture = polish
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/POL_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							primary_culture = polish
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							primary_culture = polish
+						}
+					}
+				}
+			}
+			picture = "news/POL_default_newspaper_title.dds"
+		}
+
+		# BRZ ###################
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = BRZ
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = BRZ
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/BRZ_communist_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = BRZ
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = BRZ
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/BRZ_fascist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = BRZ
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = BRZ
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/BRZ_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = BRZ
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = BRZ
+						}
+					}
+				}
+			}
+			picture = "news/BRZ_default_newspaper_title.dds"
+		}
+
+		# Spanish Latin America Nations ###########
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = ARG
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = ARG
+						}
+					}
+				}
+			}
+			picture = "news/ARG_default_newspaper_title.dds"
+		}
+
+		# Spanish Latin America Generic ###########
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = latin_american_cultures
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = latin_american_cultures
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/latinamerica_communist_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = latin_american_cultures
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = latin_american_cultures
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/latinamerica_fascist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = latin_american_cultures
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = latin_american_cultures
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/latinamerica_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = latin_american_cultures
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = latin_american_cultures
+						}
+					}
+				}
+			}
+			picture = "news/latinamerica_default_newspaper_title.dds"
+		}
+
+		# Korea #########################
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							and = {
+								primary_culture = korean
+								not = { ruling_party_ideology = communist }
+								not = { ruling_party_ideology = communist_social }
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							and = {
+								primary_culture = korean
+								not = { ruling_party_ideology = communist }
+								not = { ruling_party_ideology = communist_social }
+							}
+						}
+					}
+				}
+			}
+			picture = "news/KOR_default_newspaper_title.dds"
+		}
+
+		# JAP ###########################
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/JAP_communist_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/JAP_fascist_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/JAP_reactionary_newspaper_title.dds"
+		}
+
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = far_east_asian not = { primary_culture = korean }
+						}
+					}
+				}
+			}
+			picture = "news/JAP_default_newspaper_title.dds"
+		}
+
+		# Chinese #######################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { and = {
+							is_culture_group = east_asian
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						} }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { and = {
+							is_culture_group = east_asian
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						} }
+					}
+				}
+			}
+			picture = "news/CHI_communist_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							and = {
+								is_culture_group = east_asian
+								or = {
+									ruling_party_ideology = liberal
+									ruling_party_ideology = progressive
+								}
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							and = {
+								is_culture_group = east_asian
+								or = {
+									ruling_party_ideology = liberal
+									ruling_party_ideology = progressive
+								}
+							}
+						}
+					}
+				}
+			}
+			picture = "news/TAI_antichina_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							and = {
+								is_culture_group = east_asian
+								ruling_party_ideology = socialist
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							and = {
+								is_culture_group = east_asian
+								ruling_party_ideology = socialist
+							}
+						}
+					}
+				}
+			}
+
+			picture = "news/TAI_prochina_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { is_culture_group = east_asian }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { is_culture_group = east_asian }
+					}
+				}
+			}
+			picture = "news/TAI_default_newspaper_title.dds"
+		}
+
+		# Atjeh #########################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							or = {
+								primary_culture = ache
+								primary_culture = indonesian
+								primary_culture = malay
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							or = {
+								primary_culture = ache
+								primary_culture = indonesian
+								primary_culture = malay
+							}
+						}
+					}
+
+				}
+			}
+			picture = "news/ATJ_default_newspaper_title.dds"
+		}
+
+		# India #########################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { and = {
+							or = {
+								is_culture_group = south_asian_indian
+								is_culture_group = south_asian
+							}
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						} }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { and = {
+							or = {
+								is_culture_group = south_asian_indian
+								is_culture_group = south_asian
+							}
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						} }
+					}
+				}
+			}
+			picture = "news/IND_communist_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { and = {
+							or = {
+								is_culture_group = south_asian_indian
+								is_culture_group = south_asian
+							}
+							or = {
+								ruling_party_ideology = conservative
+								ruling_party_ideology = big_tent
+							}
+						} }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { and = {
+							or = {
+								is_culture_group = south_asian_indian
+								is_culture_group = south_asian
+							}
+							or = {
+								ruling_party_ideology = conservative
+								ruling_party_ideology = big_tent
+							}
+						} }
+					}
+				}
+			}
+			picture = "news/IND_conservative_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							and = {
+								or = {
+									is_culture_group = south_asian_indian
+									is_culture_group = south_asian
+								}
+								ruling_party_ideology = populist
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							and = {
+								or = {
+									is_culture_group = south_asian_indian
+									is_culture_group = south_asian
+								}
+								ruling_party_ideology = populist
+							}
+						}
+					}
+				}
+			}
+			picture = "news/IND_fascist_newspaper_title.dds"
+		}
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							or = {
+								is_culture_group = south_asian_indian
+								is_culture_group = south_asian
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							or = {
+								is_culture_group = south_asian_indian
+								is_culture_group = south_asian
+							}
+						}
+					}
+				}
+			}
+			picture = "news/IND_default_newspaper_title.dds"
+		}
+
+		# Israel ########################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = { is_culture_group = jewish_cultures }
+					}
+					and = {
+						is_vassal = yes
+						overlord = { is_culture_group = jewish_cultures }
+					}
+				}
+			}
+			picture = "news/ISR_default_newspaper_title.dds"
+		}
+
+		# Egypt #########################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							and = {
+								capital = 1745 # Cairo
+								ruling_party_ideology = traditionalist
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							and = {
+								capital = 1745 # Cairo
+								ruling_party_ideology = traditionalist
+							}
+						}
+					}
+				}
+			}
+			picture = "news/EGY_reactionary_newspaper_title.dds"
+		}
+		# Arab ##########################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							or = {
+								is_culture_group = arabic
+								is_culture_group = maghreb_cultures
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							or = {
+								is_culture_group = arabic
+								is_culture_group = maghreb_cultures
+							}
+						}
+					}
+				}
+			}
+			picture = "news/arabic_newspaper_title.dds"
+		}
+
+		# SAF & Bantustans ##############
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							or = {
+								tag = SAF
+								primary_culture = afrikaaner
+								primary_culture = coloured
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							or = {
+								tag = SAF
+								primary_culture = afrikaaner
+								primary_culture = coloured
+							}
+						}
+					}
+				}
+			}
+			picture = "news/SAF_default_newspaper_title.dds"
+		}
+
+		# AUS and KUK ###################
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = AUS
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = AUS
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/AUS_communist_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = AUS
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = AUS
+							ruling_party_ideology = populist
+						}
+					}
+				}
+			}
+			picture = "news/AUS_fascist_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = AUS
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = AUS
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/AUS_reactionary_newspaper_title.dds"
+		}
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = AUS
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = AUS
+						}
+					}
+				}
+			}
+			picture = "news/AUS_default_newspaper_title.dds"
+		}
+
+		# SWI ########################
+		case =	{
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							tag = SWI
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							tag = SWI
+						}
+					}
+				}
+			}
+			picture = "news/SWI_default_newspaper_title.dds"
+		}
+
+		# Germanic ###################
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_germanic_cultures
+							ruling_party_ideology = traditionalist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_germanic_cultures
+							ruling_party_ideology = traditionalist
+						}
+					}
+				}
+			}
+			picture = "news/GER_reactionary_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_germanic_cultures
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_germanic_cultures
+							or = {
+								ruling_party_ideology = communist
+								ruling_party_ideology = communist_social
+							}
+						}
+					}
+				}
+			}
+			picture = "news/GER_communist_newspaper_title.dds"
+		}
+
+		case = {
+			trigger = {
+				or = {
+					and = {
+						part_of_sphere = yes
+						sphere_owner = {
+							is_culture_group = european_germanic_cultures
+							ruling_party_ideology = populist
+						}
+					}
+					and = {
+						is_vassal = yes
+						overlord = {
+							is_culture_group = european_germanic_cultures
 							ruling_party_ideology = populist
 						}
 					}
@@ -1710,41 +2544,39 @@ style =
 		}
 
 		case =	{
-			trigger = { 
+			trigger = {
 				or = {
 					and = {
-						is_culture_group = european_germanic_cultures 
-					}
-					and = {
-						civilized = no
 						part_of_sphere = yes
-
 						sphere_owner = {
-							is_culture_group = european_germanic_cultures 
+							is_culture_group = european_germanic_cultures
 						}
 					}
 					and = {
-						civilized = no
 						is_vassal = yes
-
 						overlord = {
-							is_culture_group = european_germanic_cultures 
+							is_culture_group = european_germanic_cultures
 						}
-					}					
+					}
 				}
 			}
 			picture = "news/GER_default_newspaper_title.dds"
 		}
 
 
-		# Ruling ideology generics ########
+		# Ruling ideology generics ######
 		case =	{
-			trigger = { ruling_party_ideology = anarcho_liberal }
+			trigger = { ruling_party_ideology = liberal }
 			picture = "news/anarchoLiberal_newspaper_title.dds"
 		}
 
 		case =	{
-			trigger = { ruling_party_ideology = communist }
+			trigger = {
+				or = {
+					ruling_party_ideology = communist
+					ruling_party_ideology = communist_social
+				}
+			}
 			picture = "news/communist_newspaper_title.dds"
 		}
 
@@ -1758,12 +2590,9 @@ style =
 			picture = "news/reactionary_newspaper_title.dds"
 		}
 
-		#TODO: add ARG, ATJ, CHI, IND, ISR, PER, QUE, SAF, SER, SIA, SWI, TAI, TUR (differs from Ottoman)
-		#Replace uncivilized with some other method of newspaper distribution
-
 		# Fallback picture
-		case = { 
-			picture = "news/generic_newspaper_title.dds" 
+		case = {
+			picture = "news/generic_newspaper_title.dds"
 		}
 	}
 }


### PR DESCRIPTION
All present images used.
  Anarcho liberal replaced with liberal.
  Those without images will use that of their overlord.
  Tested.

There are some TODOs in the file, but they concern images to add. Each would require research, obviously, so that could be left up to user contributions, much like party histories.