### PR TITLE
Yugoslavia starts with all cores #111

### DIFF
--- a/CWE/events/yugoslavia.txt
+++ b/CWE/events/yugoslavia.txt
@@ -327,6 +327,7 @@ country_event = {
 	release_vassal = MON
 	release_vassal = MAC
 	random_country = { limit = { NOT = { exists = BUL } } release_vassal = BUL }
+	any_core = { limit = { NOT = { owned_by = THIS } } remove_core = THIS }
 	ai_chance = { factor = 0 }
   }
 
@@ -709,27 +710,4 @@ country_event = {
 	GER = { diplomatic_influence = { who = KOS value = 200 } }
   }
 
-}
-
-country_event = {
-  id = 8224001
-  title = EVT_8224001_NAME
-  desc = EVT_8224001_DESC
-  picture = "nwo2_yugoslav_lands"
-  fire_only_once = yes
-
-  trigger = {
-    tag = YUG
-    year = 1943 NOT = { year = 1963 }
-	NOT = { government = proletarian_dictatorship }
-    NOT = { has_country_flag  = cores_returned }
-  }
-
-  mean_time_to_happen = { months = 1  }
-
-  option = {
-    name = EVT_8224001_A
-	set_country_flag = cores_returned 
-	any_owned = { add_core =  THIS }
-  }
 }

--- a/CWE/history/provinces/austria/2538 - Novi Sad.txt
+++ b/CWE/history/provinces/austria/2538 - Novi Sad.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core =  VOJ
 trade_goods = sugar

--- a/CWE/history/provinces/austria/767 - Maribor.txt
+++ b/CWE/history/provinces/austria/767 - Maribor.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SLO
 trade_goods = timber
 life_rating = 35

--- a/CWE/history/provinces/austria/768 - Ljubljana.txt
+++ b/CWE/history/provinces/austria/768 - Ljubljana.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SLO
 trade_goods = cattle
 life_rating = 35

--- a/CWE/history/provinces/austria/769 - Postojna.txt
+++ b/CWE/history/provinces/austria/769 - Postojna.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SLO
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/austria/770 - Pola.txt
+++ b/CWE/history/provinces/austria/770 - Pola.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 add_core = TRE
 trade_goods = grain

--- a/CWE/history/provinces/austria/771 - Zagreb.txt
+++ b/CWE/history/provinces/austria/771 - Zagreb.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = timber
 life_rating = 35

--- a/CWE/history/provinces/austria/772 - Sisak.txt
+++ b/CWE/history/provinces/austria/772 - Sisak.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 add_core =  SRK
 trade_goods = cattle

--- a/CWE/history/provinces/austria/773 - Karlovac.txt
+++ b/CWE/history/provinces/austria/773 - Karlovac.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 add_core =  SRK
 trade_goods = fruit

--- a/CWE/history/provinces/austria/774 - Senj.txt
+++ b/CWE/history/provinces/austria/774 - Senj.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 add_core =  SRK
 trade_goods = timber

--- a/CWE/history/provinces/austria/775 - Varadzin.txt
+++ b/CWE/history/provinces/austria/775 - Varadzin.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/austria/776 - Bjelovar.txt
+++ b/CWE/history/provinces/austria/776 - Bjelovar.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/austria/777 - Pozega.txt
+++ b/CWE/history/provinces/austria/777 - Pozega.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/austria/778 - Fiume.txt
+++ b/CWE/history/provinces/austria/778 - Fiume.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/austria/779 - Osijek.txt
+++ b/CWE/history/provinces/austria/779 - Osijek.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = cattle
 life_rating = 35

--- a/CWE/history/provinces/austria/780 - Split.txt
+++ b/CWE/history/provinces/austria/780 - Split.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = fish
 life_rating = 35

--- a/CWE/history/provinces/austria/781 - Zadar.txt
+++ b/CWE/history/provinces/austria/781 - Zadar.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = sugar
 life_rating = 35

--- a/CWE/history/provinces/austria/782 - Dubrovnik.txt
+++ b/CWE/history/provinces/austria/782 - Dubrovnik.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 trade_goods = fish
 life_rating = 35

--- a/CWE/history/provinces/austria/791 - Mitrovica.txt
+++ b/CWE/history/provinces/austria/791 - Mitrovica.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core =  VOJ
 trade_goods = oil_seeds

--- a/CWE/history/provinces/austria/792 - Pancevo.txt
+++ b/CWE/history/provinces/austria/792 - Pancevo.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core =  VOJ
 trade_goods = grain

--- a/CWE/history/provinces/austria/793 - Vukovar.txt
+++ b/CWE/history/provinces/austria/793 - Vukovar.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = CRO
 add_core =  SRK
 trade_goods = cattle

--- a/CWE/history/provinces/balkan/2569 - Niksic.txt
+++ b/CWE/history/provinces/balkan/2569 - Niksic.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core = MON
 trade_goods = timber

--- a/CWE/history/provinces/balkan/2577 - Pljevlja.txt
+++ b/CWE/history/provinces/balkan/2577 - Pljevlja.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core = MON
 trade_goods = bauxite

--- a/CWE/history/provinces/balkan/2582 - Kotor.txt
+++ b/CWE/history/provinces/balkan/2582 - Kotor.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core = MON
 trade_goods = fruit

--- a/CWE/history/provinces/balkan/2583 - Cetinje.txt
+++ b/CWE/history/provinces/balkan/2583 - Cetinje.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core = MON
 trade_goods = other_minerals

--- a/CWE/history/provinces/balkan/783 - Sarajevo.txt
+++ b/CWE/history/provinces/balkan/783 - Sarajevo.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = BOS
 trade_goods = bauxite
 life_rating = 35

--- a/CWE/history/provinces/balkan/784 - Bihac.txt
+++ b/CWE/history/provinces/balkan/784 - Bihac.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = BOS
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/balkan/785 - Banja Luka.txt
+++ b/CWE/history/provinces/balkan/785 - Banja Luka.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = BOS
 add_core = RSR
 trade_goods = timber

--- a/CWE/history/provinces/balkan/786 - Tuzla.txt
+++ b/CWE/history/provinces/balkan/786 - Tuzla.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = BOS
 add_core = RSR
 trade_goods = grain

--- a/CWE/history/provinces/balkan/787 - Foca.txt
+++ b/CWE/history/provinces/balkan/787 - Foca.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = BOS
 add_core = RSR
 trade_goods = other_minerals

--- a/CWE/history/provinces/balkan/788 - Mostar.txt
+++ b/CWE/history/provinces/balkan/788 - Mostar.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = BOS
 add_core = HZB
 trade_goods = timber

--- a/CWE/history/provinces/balkan/789 - Livno.txt
+++ b/CWE/history/provinces/balkan/789 - Livno.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = BOS
 add_core = RSR
 trade_goods = timber

--- a/CWE/history/provinces/balkan/794 - Belgrade.txt
+++ b/CWE/history/provinces/balkan/794 - Belgrade.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/balkan/795 - Bor.txt
+++ b/CWE/history/provinces/balkan/795 - Bor.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/balkan/796 - Kragujevac.txt
+++ b/CWE/history/provinces/balkan/796 - Kragujevac.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 trade_goods = other_minerals
 life_rating = 35

--- a/CWE/history/provinces/balkan/797 - Uzice.txt
+++ b/CWE/history/provinces/balkan/797 - Uzice.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/balkan/798 - Nis.txt
+++ b/CWE/history/provinces/balkan/798 - Nis.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 trade_goods = oil_seeds
 life_rating = 35

--- a/CWE/history/provinces/balkan/799 - Leskovac.txt
+++ b/CWE/history/provinces/balkan/799 - Leskovac.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 trade_goods = timber
 life_rating = 35

--- a/CWE/history/provinces/balkan/800 - Ulcinj.txt
+++ b/CWE/history/provinces/balkan/800 - Ulcinj.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core = MON
 trade_goods = grain

--- a/CWE/history/provinces/balkan/802 - Pristina.txt
+++ b/CWE/history/provinces/balkan/802 - Pristina.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core = KOS
 trade_goods = grain

--- a/CWE/history/provinces/balkan/803 - Prizren.txt
+++ b/CWE/history/provinces/balkan/803 - Prizren.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 add_core = KOS
 trade_goods = timber

--- a/CWE/history/provinces/balkan/804 - Novi Pazar.txt
+++ b/CWE/history/provinces/balkan/804 - Novi Pazar.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = SER
 trade_goods = grain
 life_rating = 35

--- a/CWE/history/provinces/balkan/806 - Skopje.txt
+++ b/CWE/history/provinces/balkan/806 - Skopje.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = MAC
 trade_goods = iron
 life_rating = 35

--- a/CWE/history/provinces/balkan/807 - Bitola.txt
+++ b/CWE/history/provinces/balkan/807 - Bitola.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = MAC
 trade_goods = tobacco
 life_rating = 35

--- a/CWE/history/provinces/soviet/2688 - Inta.txt
+++ b/CWE/history/provinces/soviet/2688 - Inta.txt
@@ -1,5 +1,6 @@
 owner = YUG
 controller = YUG
+add_core = YUG
 add_core = BOS
 add_core = HZB
 trade_goods = coal

--- a/CWE/localisation/nwo_events.csv
+++ b/CWE/localisation/nwo_events.csv
@@ -4142,9 +4142,6 @@ EVT_8223003_A;Great!;;;;;;;;;;X
 EVT_8224000_NAME;Poland is free;;;;;;;;;;X
 EVT_8224000_DESC;After self-liberation during the course of WW2, we claim our rightful possessions once more.;;;;;;;;;;X
 EVT_8224000_A;OK;;;;;;;;;;X
-EVT_8224001_NAME;Yugoslavia is free;;;;;;;;;;X
-EVT_8224001_DESC;After self-liberation during the course of WW2, we claim our rightful possessions once more.;;;;;;;;;;X
-EVT_8224001_A;OK;;;;;;;;;;X
 EVT_8225000_NAME;Our control over our bloc strenghtens;;;;;;;;;;X
 EVT_8225000_DESC;After the recent turn of events in $FROMCOUNTRY$, our support of communist causes and related fortunate circumstances have allowed us to further tighten our grip over our allies' bloc.;;;;;;;;;;X
 EVT_8225000_A;Our control is now more confident;;;;;;;;;;X


### PR DESCRIPTION
Removed on 1974 constitution except for Serb lands.
  In the event of rejecting the 1974 constitution, a dissolved Yugoslavia could declare war to reunify.

Post-dissolution Yugoslavia is actually Serbia, which has all its cores in place.

Balkan unification does not grant cores currently. I don't think there is any reason for this, though.

