### PR TITLE
Use width of politics window for modifer icons

### DIFF
--- a/CWE/interface/country_politics.gui
+++ b/CWE/interface/country_politics.gui
@@ -180,9 +180,9 @@ guiTypes = {
 		### COUNTRY MODIFIERS
 		OverlappingElementsBoxType = {
 			name = "country_modifier_overlappingbox"
-			position = { x = 630 y = -35 }
-			size = { x=200 y= 32 }
-			Orientation = "UPPER_LEFT"
+			position = { x = 0 y = -35 }
+			size = { x=830 y= 32 }
+			Orientation = "UPPER_RIGHT"
 			format = right
 			spacing = 1.0
 		}


### PR DESCRIPTION
Start near the top right and expand left. Works on lower resolutions. Screenshots:

Many icons
  ![v2_7](https://cloud.githubusercontent.com/assets/8064135/25466695/25a2cad6-2ad8-11e7-8c03-b8714585506b.jpg)

Few icons
  ![v2_8](https://cloud.githubusercontent.com/assets/8064135/25466735/58e59fe0-2ad8-11e7-8b4c-30290713586b.jpg)

I haven't found any problems with this approach, though I have only tested it briefly.

It's possible that it looks cramped. I'd value an opinion on this; maybe it would be better to align the left edge with the vertical divider rather than the edge of the window. Either way, I think it's an improvement on the current system, and does let you actually browse your modifiers.