### PR TITLE
Subsequent claim greater decisions + naming Epirus back

### DIFF
--- a/CWE/decisions/claim_greater.txt
+++ b/CWE/decisions/claim_greater.txt
@@ -1257,171 +1257,286 @@ political_decisions = {
 
         }
 
-        claim_greater_greece = {
+		claim_greater_greece = {
 				picture = "claim_greater_greece"
-                potential = {
-                        tag = GRE
-                        NOT = { has_country_flag = claim_greater_greece }
-                }
+				potential = {
+					OR = {
+						tag = GRE
+						tag = UGR
+					}
+					NOT = { has_country_flag = claim_greater_greece }
+				}
 
-                allow = {
-                       tag = GRE
-						part_of_sphere = no
-						has_unclaimed_cores = no
-						NOT = {	
-							has_country_flag = claim_greater_greece
+				allow = {
+					part_of_sphere = no
+					has_unclaimed_cores = no
+					NOT = { OR = {
+						ruling_party_ideology = socialist
+						ruling_party_ideology = progressive
+						ruling_party_ideology = liberal 
+					} }
+					is_vassal = no
+					prestige = 45
+					OR = {
+							ruling_party_ideology = populist
+							jingoism = 24
+					}
+				}
+
+				effect = {
+					badboy = 12
+					set_country_flag = claim_greater_greece
+					869 = { add_core = THIS }
+					828 = { add_core = THIS }
+					859 = { add_core = THIS }
+					858 = { add_core = THIS }
+				}
+
+		}
+		abandon_claim_greater_greece = {
+				picture = "claim_greater_greece"
+				potential = {
+					has_country_flag = claim_greater_greece
+					OR = {
+							government = democracy
+							government = hms_government
+					}
+				}
+
+				allow = {
+					war = no
+					is_vassal = no
+					has_country_flag = claim_greater_greece
+					OR = {
 							ruling_party_ideology = socialist
 							ruling_party_ideology = progressive
-							ruling_party_ideology = liberal 
-						}
-						is_vassal = no
-                        prestige = 45
-                        OR = {
-                                ruling_party_ideology = populist
-                                jingoism = 24
-                        }
-                }
+							ruling_party_ideology = liberal
+					}
+				}
 
-                effect = {
-                        badboy = 12
-                        set_country_flag = claim_greater_greece
-                        869 = { add_core = GRE }
-                        828 = { add_core = GRE }
-                        859 = { add_core = GRE }
-                        858 = { add_core = GRE }
-                }
+				effect = {
+					prestige = 10
+					any_pop = {
+							consciousness = 1
+					}
+					clr_country_flag = claim_greater_greece
+					all_core = { 
+							limit = { NOT = { owned_by = THIS } OR = { is_primary_culture = yes is_accepted_culture  = yes } }
+							remove_core = THIS
+					}
+				}
 
-        }
-        abandon_claim_greater_greece = {
-				picture = "claim_greater_greece"
-                potential = {
-                        tag = GRE
-                        has_country_flag = claim_greater_greece
-                        OR = {
-                                government = democracy
-                                government = hms_government
-                        }
-                }
+		}
 
-                allow = {
-                        war = no
-                        is_vassal = no
-                        has_country_flag = claim_greater_greece
-                        OR = {
-                                ruling_party_ideology = socialist
-                                ruling_party_ideology = progressive
-                                ruling_party_ideology = liberal
-                        }
-                }
+		claim_northern_epirus = {
+			picture = "claim_greater_greece"
+			potential = {
+				OR = {
+					tag = GRE
+					tag = UGR
+				}
+				NOT = { has_country_flag = claim_northern_epirus }
+			}
+			allow = {
+				has_unclaimed_cores = no
+				NOT = { OR = {
+					ruling_party_ideology = socialist
+					ruling_party_ideology = progressive
+					ruling_party_ideology = liberal
+				} }
+				prestige = 20
+				OR = {
+					ruling_party_ideology = populist
+					jingoism = 10
+				}
+			}
+			effect = {
+				badboy = 4
+				set_country_flag = claim_northern_epirus
+				853 = { add_core = THIS } # Gjirokaster
+			}
+		}
 
-                effect = {
-						prestige = 10
-                        any_pop = {
-                                consciousness = 1
-                        }
-                        clr_country_flag = claim_greater_greece
-                        all_core = { 
-                                limit = { NOT = { owned_by = THIS } OR = { is_primary_culture = yes is_accepted_culture  = yes } }
-                                remove_core = GRE
-                        }
-                }
+		abandon_claim_northern_epirus = {
+			picture = "claim_greater_greece"
+			potential = {
+				has_country_flag = claim_northern_epirus
+				OR = {
+					government = democracy
+					government = hms_government
+				} 
+			}
+			allow = {
+				war = no
+				is_vassal = no
+				has_country_flag = claim_northern_epirus
+				OR = {
+					ruling_party_ideology = socialist
+					ruling_party_ideology = progressive
+					ruling_party_ideology = liberal
+				}
+			}
+			effect = {
+				prestige = 10
+				any_pop = {
+					consciousness = 1
+				}
+				clr_country_flag = claim_northern_epirus
+				all_core = { 
+					limit = { NOT = { owned_by = THIS } OR = { is_primary_culture = yes is_accepted_culture  = yes } }
+					remove_core = THIS
+				}
+			} 
+		}
 
-        }
 
-        claim_greater_india = {
+		claim_greater_india = {
 				picture = "claim_greater_india"
-                potential = {
-                        tag = HND
-                        NOT = { has_country_flag = claim_greater_india }
-                }
+				potential = {
+						tag = HND
+						NOT = { has_country_flag = claim_greater_india }
+				}
 
-                allow = {
-                       tag = HND
+				allow = {
 						part_of_sphere = no
 						has_unclaimed_cores = no
-						NOT = {	
-							has_country_flag = claim_greater_india
+						NOT = { OR = {
 							ruling_party_ideology = socialist
 							ruling_party_ideology = progressive
 							ruling_party_ideology = liberal 
-						}
+						} }
 						is_vassal = no
-                        prestige = 45
-                        OR = {
-                                ruling_party_ideology = populist
-                                jingoism = 24
-                        }
-                }
+						prestige = 45
+						OR = {
+							ruling_party_ideology = populist
+							jingoism = 24
+						}
+				}
 	
-                effect = {
-                        badboy = 12
-                        set_country_flag = claim_greater_india
-                        1256 = { add_core = HND }
-                        1257 = { add_core = HND }
-                        1254 = { add_core = HND }
-                        1255 = { add_core = HND }
-                        1290 = { add_core = HND }
-                        1288 = { add_core = HND }
-                        1289 = { add_core = HND }
-                        1222 = { add_core = HND }
-                        1221 = { add_core = HND }
-                        1220 = { add_core = HND }
-                        1219 = { add_core = HND }
-                        1218 = { add_core = HND }
-                        1223 = { add_core = HND }
-                        1231 = { add_core = HND }
-                        1228 = { add_core = HND }
-                        1232 = { add_core = HND }
-                        1227 = { add_core = HND }
-                        1229 = { add_core = HND }
-                        1230 = { add_core = HND }
-                        2673 = { add_core = HND } # Lyallpar 
-                        2653  = { add_core = HND } # Tribal Areas
-						2692  = { add_core = HND } # Rangpur
-						2666  = { add_core = HND } # Mymensingh
-						1070  = { add_core = HND } # Sylhet
-						2637  = { add_core = HND } # Narayanganj
-						2657  = { add_core = HND } # Khulna
-						2658  = { add_core = HND } # Comilla
-						2680  = { add_core = HND } # Chittagong Hill Tracts
-                }
+				effect = {
+						badboy = 12
+						set_country_flag = claim_greater_india
+						1256 = { add_core = THIS }
+						1257 = { add_core = THIS }
+						1254 = { add_core = THIS }
+						1255 = { add_core = THIS }
+						1290 = { add_core = THIS }
+						1288 = { add_core = THIS }
+						1289 = { add_core = THIS }
+						1222 = { add_core = THIS }
+						1221 = { add_core = THIS }
+						1220 = { add_core = THIS }
+						1219 = { add_core = THIS }
+						1218 = { add_core = THIS }
+						1223 = { add_core = THIS }
+						1231 = { add_core = THIS }
+						1228 = { add_core = THIS }
+						1232 = { add_core = THIS }
+						1227 = { add_core = THIS }
+						1229 = { add_core = THIS }
+						1230 = { add_core = THIS }
+						2673 = { add_core = THIS } # Lyallpar 
+						2653  = { add_core = THIS } # Tribal Areas
+						2692  = { add_core = THIS } # Rangpur
+						2666  = { add_core = THIS } # Mymensingh
+						1070  = { add_core = THIS } # Sylhet
+						2637  = { add_core = THIS } # Narayanganj
+						2657  = { add_core = THIS } # Khulna
+						2658  = { add_core = THIS } # Comilla
+						2680  = { add_core = THIS } # Chittagong Hill Tracts
+				}
 
-        }
-        abandon_claim_greater_india = {
+		}
+		abandon_claim_greater_india = {
 				picture = "claim_greater_india"
-                potential = {
-                        tag = HND
-                        has_country_flag = claim_greater_india
-                        OR = {
-                                government = democracy
-                                government = hms_government
-                        }
-                }
+				potential = {
+						tag = HND
+						has_country_flag = claim_greater_india
+						OR = {
+								government = democracy
+								government = hms_government
+						}
+				}
 
-                allow = {
-                        war = no
-                        is_vassal = no
-                        has_country_flag = claim_greater_india
-                        OR = {
-                                ruling_party_ideology = socialist
-                                ruling_party_ideology = progressive
-                                ruling_party_ideology = liberal
-                        }
-                }
+				allow = {
+						war = no
+						is_vassal = no
+						has_country_flag = claim_greater_india
+						OR = {
+								ruling_party_ideology = socialist
+								ruling_party_ideology = progressive
+								ruling_party_ideology = liberal
+						}
+				}
 
-                effect = {
+				effect = {
 						prestige = 10
-                        any_pop = {
-                                consciousness = 1
-                        }
-                        clr_country_flag = claim_greater_india
-                        all_core = { 
-                                limit = { NOT = { owned_by = THIS } OR = { is_primary_culture = yes is_accepted_culture  = yes } }
-                                remove_core = HND
-                        }
-                }
+						any_pop = {
+								consciousness = 1
+						}
+						clr_country_flag = claim_greater_india
+						all_core = { 
+								limit = { NOT = { owned_by = THIS } OR = { is_primary_culture = yes is_accepted_culture  = yes } }
+								remove_core = HND
+						}
+				}
 
-        }
+		}
+
+		claim_tamil_ceylon = {
+			picture = "claim_greater_india"
+			potential = {
+				tag = HND
+				NOT = { has_country_flag = claim_tamil_ceylon }
+			}
+			allow = {
+				has_unclaimed_cores = no
+				prestige = 20
+				NOT = { ruling_party_ideology = liberal }
+				NOT = { ruling_party_ideology = progressive }
+				OR = {
+					ruling_party_ideology = populist
+					ruling_party_ideology = nationalist
+					jingoism = 10
+				}
+			}
+			effect = {
+				badboy = 4
+				set_country_flag = claim_tamil_ceylon
+				TAE = { all_core = { add_core = THIS } } # Tamil Eelam
+			}
+		}
+
+		abandon_claim_tamil_ceylon = {
+			picture = "claim_greater_india"
+			potential = {
+				has_country_flag = claim_tamil_ceylon
+				OR = {
+					government = democracy
+					government = hms_government
+				} 
+			}
+			allow = {
+				war = no
+				is_vassal = no
+				has_country_flag = claim_tamil_ceylon
+				OR = {
+					ruling_party_ideology = progressive
+					ruling_party_ideology = liberal
+				} 
+			}
+			effect = {
+				prestige = 10
+				any_pop = {
+					consciousness = 1
+				}
+				clr_country_flag = claim_tamil_ceylon
+				all_core = { 
+					limit = { NOT = { owned_by = THIS } OR = { is_primary_culture = yes is_accepted_culture  = yes } }
+					remove_core = THIS
+				}
+			} 
+		}
 
         claim_greater_hungary = {
 				picture = "claim_greater_hungary"
@@ -1663,15 +1778,9 @@ political_decisions = {
 			}
 
 			allow = {
-				tag = ISR
 				#part_of_sphere = no
 				has_unclaimed_cores = no
-				owns = 917
-				NOT = {	
-					has_country_flag = claim_greater_israel
-					ruling_party_ideology = progressive
-					ruling_party_ideology = liberal 
-				}
+				owns = 917 # Jerusalem
 				is_vassal = no
 				#prestige = 45
 				OR = {
@@ -1688,7 +1797,7 @@ political_decisions = {
 				badboy = 12
 				prestige = 45
 				set_country_flag = claim_greater_israel
-				EGY_910 = { add_core = ISR }
+				EGY_910 = { add_core = THIS } # Transjordan
 			}
 
 		}
@@ -1707,7 +1816,10 @@ political_decisions = {
 			allow = {
 				war = no
 				is_vassal = no
-				has_country_flag = claim_greater_israel
+				OR = {
+					has_country_flag = claim_greater_israel
+					has_country_flag = claim_greater_israel_1
+				}
 				OR = {
 					ruling_party_ideology = progressive
 					ruling_party_ideology = liberal
@@ -1720,10 +1832,42 @@ political_decisions = {
 					consciousness = 1
 				}
 				clr_country_flag = claim_greater_israel
+				clr_country_flag = claim_greater_israel_1
 				all_core = { 
 					limit = { NOT = { owned_by = THIS } OR = { is_primary_culture = yes is_accepted_culture  = yes } }
-					remove_core = ISR
+					remove_core = THIS
 				}
+			}
+
+		}
+
+		claim_greater_israel_1 = {
+			picture = "claim_greater_israel"
+			potential = {
+				PAL = { exists = no }
+				tag = ISR
+				NOT = { has_country_flag = claim_greater_israel_1 }
+			}
+
+			allow = {
+				#part_of_sphere = no
+				has_unclaimed_cores = no
+				owns = 917
+				owns = 915 # Sidon, from Lebanese CW
+				is_vassal = no
+				#prestige = 45
+				OR = {
+					ruling_party_ideology = nationalist
+					ruling_party_ideology = populist
+					jingoism = 24
+				}
+			}
+
+			effect = {
+				badboy = 12
+				prestige = 45
+				set_country_flag = claim_greater_israel_1
+				EGY_915 = { add_core = ISR } # Lebanon
 			}
 
 		}

--- a/CWE/decisions/greece.txt
+++ b/CWE/decisions/greece.txt
@@ -21,78 +21,46 @@ political_decisions = {
 		}
 	}
 
-
-
-claim_northern_epirus = {
-		picture = "claim_greater_greece"
-		potential = {
-			tag = GRE
-			NOT = { has_country_flag = claim_northern_epirus } }
-		allow = {
-			tag = GRE
-			NOT = {	
-				has_country_flag = claim_northern_epirus
-				ruling_party_ideology = socialist
-				ruling_party_ideology = progressive
-				ruling_party_ideology = liberal }
-			prestige = 20
-			OR = {
-				ruling_party_ideology = populist
-				jingoism = 10 } }
-		effect = {
-			badboy = 4
-			set_country_flag = claim_northern_epirus
-			853 = { add_core = GRE } 
-		} 
-	}
-
-	abandon_claim_northern_epirus = {
-		picture = "claim_greater_greece"
-		potential = {
-			tag = GRE
-			has_country_flag = claim_northern_epirus
-			OR = {
-				government = democracy
-				government = hms_government } 
-		}
-		allow = {
-			war = no
-			is_vassal = no
-			has_country_flag = claim_northern_epirus
-			OR = {
-				ruling_party_ideology = socialist
-				ruling_party_ideology = progressive
-				ruling_party_ideology = liberal } 
-		}
-		effect = {
-			prestige = 10
-			any_pop = {
-				consciousness = 1 }
-			clr_country_flag = claim_northern_epirus
-			all_core = { 
-				limit = { NOT = { owned_by = THIS } OR = { is_primary_culture = yes is_accepted_culture  = yes } }
-				remove_core = GRE } 
-		} 
-	}
-
 	greek_epirus = {
 		picture = "unite_with_greece"
 		potential = {
-			tag = GRE
+			primary_culture = greek
 			owns = 853
 			NOT = {
-				has_global_flag = greek_epirus } 
+				has_global_flag = greek_epirus
+			}
+		}
+		allow = {
+			election = no
+			NOT = { ruling_party_ideology = liberal }
+			NOT = { ruling_party_ideology = progressive }
+		}
+		effect = {
+			prestige = 15
+			853 = { change_province_name = "Argyrokastro" }
+			set_global_flag = greek_epirus 
+		}
+	}
+
+	albanian_epirus = {
+		picture = "claim_greater_albania"
+		potential = {
+			primary_culture = albanian
+			owns = 853
+			has_global_flag = greek_epirus
 		}
 		allow = { 
 			election = no
-NOT = { ruling_party_ideology = liberal ruling_party_ideology = progressive }
+			NOT = {
+				is_vassal = yes
+				overlord = { primary_culture = greek }
 			}
+		}
 		effect = {
-	853 = { change_province_name = "Argyrokastro" }
-		set_global_flag = greek_epirus 
-			} 
-}
-
-
+			prestige = 15
+			853 = { change_province_name = "Gjirokaster" }
+			clr_global_flag = greek_epirus 
+		} 
+	}
 
 }

--- a/CWE/localisation/claim_greater.csv
+++ b/CWE/localisation/claim_greater.csv
@@ -28,12 +28,20 @@ claim_greater_comoros_desc;The Union of the Comoros is a republic, composed of t
 claim_greater_india;Akhand Bharat;;;;;;;;;;;;x
 claim_greater_india_title;Akhand Bharat;;;;;;;;;;;;x
 claim_greater_india_desc;Akhand Bharat, literally Undivided India, is an irredentist call to reunite Pakistan and Bangladesh with India to form an Undivided India as it existed before partition in 1947 (and before that, during other periods of political unity in South Asia, such as during the Mauryan Empire, the Gupta Empire, the Mughal Empire or the Maratha Empire ). ;;;;;;;;;;;;x
+claim_tamil_ceylon;Dravida Nadu;;;;;;;;;;;;x
+claim_tamil_ceylon_title;Dravida Nadu;;;;;;;;;;;;x
+claim_tamil_ceylon_desc;If we are to claim we are the state of the Dravidian peoples, we must recognize their claims to the Tamil-speaking region in Ceylon. In addition, we must save our fellow Hindus and allow them to practice their religion free in their own country - $COUNTRY$.;;;;;;;;;;;;x
+abandon_claim_tamil_ceylon_title;Abandon Ceylonese Claims;;;;;;;;;;;;x
+abandon_claim_tamil_ceylon_desc;The Sinhalese People have lived in Sri Lanka for thousands of years, and the whole of it belongs to them. We should be encouraging our Tamil brothers to move back to $COUNTRY$, not taking another nation's sovereign territory for an unwilling people.;;;;;;;;;;;;x
 claim_greater_indonesia;Claim Greater Indonesia;;;;;;;;;;;;x
 claim_greater_indonesia_title;Indonesia Raya;;;;;;;;;;;;x
 claim_greater_indonesia_desc;Greater Indonesia, or in Indonesian and Malaysian, Indonesia Raya or Melayu Raya was a political concept that sought to bring the so-called Malay race together by uniting the British territories of Malaya and Borneo with the Dutch East Indies.;;;;;;;;;;;;x
 claim_greater_israel;Revisionist Zionism;;;;;;;;;;;;x
 claim_greater_israel_title;Revisionist Zionism;;;;;;;;;;;;x
 claim_greater_israel_desc;Revisionism was distinguished primarily from other ideologies within Zionism by its territorial maximalism. While not the only group to do so, they insisted upon the Jewish right to sovereignty over the whole territory of Eretz Yisrael (originally encompassing all of Mandatory Palestine).;;;;;;;;;;;;x
+claim_greater_israel_1;Land of Milk and Honey;;;;;;;;;;;;x
+claim_greater_israel_1_title;Land of Milk and Honey;;;;;;;;;;;;x
+claim_greater_israel_1_desc;The Promised Land was given by G-d to the descendands of Abraham - the Jewish people. We have earned most of the Land already, but around half is possessed by an inconvenient state to the north. We must take it: our irrefutable claim on the land is in their holy book, too, after all.;;;;;;;;;;;;x
 claim_greater_korea;Greater Korea;;;;;;;;;;;;x
 claim_greater_korea_title;Claim Greater Korea;;;;;;;;;;;;x
 claim_greater_korea_desc;The term Greater Korea is a pan-nationalist and irredentist concept of lands that are considered to form the national homeland by most Koreans. Beside Korea, it includes Gando. Sometimes it includes Daemado an ethnically Japanese area, but geographically closer to Korea. The term is also used for referring economic ties between the relevant regions.;;;;;;;;;;;;x
@@ -58,6 +66,11 @@ claim_greater_bulgaria_desc;Greater Bulgaria is a term to identify the territory
 claim_greater_greece;Megali Idea;;;;;;;;;;;;x
 claim_greater_greece_title;Megali Idea;;;;;;;;;;;;x
 claim_greater_greece_desc;The Megali Idea ("Great Idea") was an irredentist concept of Greek nationalism that expressed the goal of establishing a Greek state that would encompass all ethnic Greek-inhabited areas, including the large Greek populations that, after the restoration of Greek independence in 1830 from the Ottoman Empire, still lived under Ottoman occupation.;;;;;;;;;;;;x
+abandon_claim_northern_epirus_title;Northern Epirus is Albanian;;;;;;;;x;;;;;;;;;;;;;
+abandon_claim_northern_epirus_desc;For too long, the Albanians have held control over Northern Epirus, lands traditionally inhabited by Greek people. We have to accept that they are part of Albania.;;;;;;;;x;;;;;;;;;;;;;
+claim_northern_epirus;Greek Northern Epirus;;;;;;;;x;;;;;;;;;;;;;
+claim_northern_epirus_title;Greek Northern Epirus;;;;;;;;x;;;;;;;;;;;;;
+claim_northern_epirus_desc;For too long, the Albanians have held control over Northern Epirus, lands traditionally inhabited by Greek people. Now is the time for $COUNTRY$ to take back what is rightfully hers.;;;;;;;;x;;;;;;;;;;;;;
 claim_greater_hungary;Hungarian irredentism;;;;;;;;;;;;x
 claim_greater_hungary_title;Hungarian irredentism;;;;;;;;;;;;x
 claim_greater_hungary_desc;Hungarian irredentism is a broad umbrella term consisting of irredentist and pan-nationalist political ideas. The idea is associated with Hungarian revisionism. Its main goal is to restore part of the pre-ww1 borders of the Kingdom of Hungary.;;;;;;;;;;;;x

--- a/CWE/localisation/nwo_decisions.csv
+++ b/CWE/localisation/nwo_decisions.csv
@@ -6,11 +6,6 @@
 ##;;;;;;;;;;;X
 claims_conference_title;Claims Conference;;;;;;;;;;X
 claims_conference_desc;The Conference on Jewish Material Claims Against Germany, or Claims Conference, represents the world's Jews in negotiating for compensation and restitution for victims of Nazi persecution and their heirs. The Claims Conference administers compensation funds, recovers unclaimed Jewish property, and allocates funds to institutions that provide social welfare services to Holocaust survivors and preserve the memory and lessons of the Shoah.;;;;;;;;;;X
-abandon_claim_northern_epirus_title;Northern Epirus is Albanian;;;;;;;;x;;;;;;;;;;;;;
-abandon_claim_northern_epirus_desc;For too long the Albanians have held control over Northern Epirus, lands traditionally inhabited by Greek people. We have to accept that those are part of Albania.;;;;;;;;x;;;;;;;;;;;;;
-claim_northern_epirus;Greek Northern Epirus;;;;;;;;x;;;;;;;;;;;;;
-claim_northern_epirus_title;Greek Northern Epirus;;;;;;;;x;;;;;;;;;;;;;
-claim_northern_epirus_desc;For too long the Albanians have held control over Northern Epirus, lands traditionally inhabited by Greek people. Now is the time for Greece to take back what is rightfully hers.;;;;;;;;x;;;;;;;;;;;;;
 greek_epirus;Rename Greek Epirus;;;;;;;;x;;;;;;;;;;;;;
 greek_epirus_title;Rename Greek Epirus;;;;;;;;x;;;;;;;;;;;;;
 greek_epirus_desc;Now that we control North Epirus, we should rename the towns and cities back to their Greek names.;;;;;;;;x;;;;;;;;;;;;;


### PR DESCRIPTION
Allow Albania to change Epirus back if reconquered. Adds another "small" claim like Epirus, for India with the Sri Lankan Tamils, and one "big" claim, for Israel with Lebanon. Also localization.