### PR TITLE
Better Indian starting pops #133

### DIFF
--- a/CWE/history/pops/1946.1.1/Beroda.txt
+++ b/CWE/history/pops/1946.1.1/Beroda.txt
@@ -1,342 +1,404 @@
 #Rajkot - Gujarat (4600000/1150000 POPS)
 1292 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 2248
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 51
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 8993
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 207
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 44965
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1035
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1124
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 25
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5620
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 129
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 11241
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 258
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 12495
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 287
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 812612
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 18704
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 208327
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 1164
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 25
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 4661
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 107
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 23309
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 536
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 582
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2913
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 66
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 5826
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 133
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 6477
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 148
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 421257
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 9695
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 107996
+    }
 }
 #Mandvi - Gujarat (874000/218500 POPS)
 1293 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 427
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 9
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1708
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 39
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 8543
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 196
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 213
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 1067
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 24
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 2135
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 49
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 2373
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 54
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 154398
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 3553
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 39580
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 221
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 884
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 4428
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 101
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 110
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 552
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 1106
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 25
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1229
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 27
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 80039
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 1841
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 20517
+    }
 }
 #Patan - Gujarat (2712000/678000 POPS)
 1294 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 1325
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 30
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 5301
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 122
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 26509
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 610
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 662
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 15
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3313
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 76
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 6627
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 152
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 7366
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 169
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 599147
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 13791
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 686
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 2747
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 62
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 13741
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 316
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 342
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 7
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 1717
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 38
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 3435
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 78
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 3818
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 87
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 310597
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 7148
+    }
 }
 #Beroda - Gujarat (3771000/942750 POPS)
 1295 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 1842
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 42
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 7372
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 169
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 36861
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 848
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 920
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 21
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 4606
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 106
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 9214
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 212
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 10243
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 235
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 833106
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 19176
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 954
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 21
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 3821
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 87
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 19108
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 439
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 476
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2387
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 54
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 4776
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 109
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 5309
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 121
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 431881
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 9940
+    }
 }

--- a/CWE/history/pops/1946.1.1/France.txt
+++ b/CWE/history/pops/1946.1.1/France.txt
@@ -103,86 +103,101 @@
 }
 #Pondicherry - Pondicherry (2535000/633750 POPS)
 1312 = {
-	officers = {
-		culture = tamil
-		religion =  hindu 
-		size = 1858
-	 } 
-	officers = {
-		culture = tamil
-		religion = secularism
-		size = 42
-	 } 
-	soldiers = {
-		culture = tamil
-		religion =  hindu 
-		size = 7433
-	 } 
-	soldiers = {
-		culture = tamil
-		religion = secularism
-		size = 171
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion =  hindu 
-		size = 24779
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion = secularism
-		size = 570
-	 } 
-	bureaucrats = {
-		culture = tamil
-		religion =  hindu 
-		size = 618
-	 } 
-	bureaucrats = {
-		culture = tamil
-		religion = secularism
-		size = 14
-	 } 
-	capitalists = {
-		culture = tamil
-		religion =  hindu 
-		size = 3096
-	 } 
-	capitalists = {
-		culture = tamil
-		religion = secularism
-		size = 71
-	 } 
-	clergymen = {
-		culture = tamil
-		religion =  hindu 
-		size = 6194
-	 } 
-	clergymen = {
-		culture = tamil
-		religion = secularism
-		size = 142
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 6850
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 157
-	 } 
-	farmers = {
-		culture = tamil
-		religion =  hindu 
-		size = 557215
-	 } 
-	farmers = {
-		culture = tamil
-		religion = secularism
-		size = 12825
-	 } 
+    officers = {
+        culture = tamil
+        religion = hindu
+        size = 1337
+    }
+
+    officers = {
+        culture = tamil
+        religion = secularism
+        size = 30
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = hindu
+        size = 5351
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = secularism
+        size = 123
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = hindu
+        size = 17840
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = secularism
+        size = 410
+    }
+
+    bureaucrats = {
+        culture = tamil
+        religion = hindu
+        size = 444
+    }
+
+    bureaucrats = {
+        culture = tamil
+        religion = secularism
+        size = 10
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = hindu
+        size = 2229
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = secularism
+        size = 51
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = hindu
+        size = 4459
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = secularism
+        size = 102
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 4932
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 113
+    }
+
+    farmers = {
+        culture = tamil
+        religion = hindu
+        size = 401194
+    }
+
+    farmers = {
+        culture = tamil
+        religion = secularism
+        size = 9234
+    }
 }
 #Tourane - Tourane (742000/185500 POPS)
 1377 = {

--- a/CWE/history/pops/1946.1.1/Gwalior.txt
+++ b/CWE/history/pops/1946.1.1/Gwalior.txt
@@ -1,88 +1,104 @@
 #Gwalior - Madhya Pradesh (6072000/1518000 POPS)
 1270 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 2967
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 68
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 11870
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 273
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 59353
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1366
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1483
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 34
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7419
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 170
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14838
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 341
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16493
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 379
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1280387
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 29471
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 62473
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 2136
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 48
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 8546
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 196
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 42734
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 983
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 1067
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 24
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5341
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 122
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10683
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 245
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11874
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 272
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 921878
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 21219
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 44980
+    }
 }

--- a/CWE/history/pops/1946.1.1/Hyderabad.txt
+++ b/CWE/history/pops/1946.1.1/Hyderabad.txt
@@ -1,370 +1,436 @@
 #Hyderabad - Terangala (3688000/922000 POPS)
 1283 = {
-	officers = {
-		culture = telegu
-		religion =  hindu 
-		size = 1802
-	 } 
-	officers = {
-		culture = telegu
-		religion = secularism
-		size = 41
-	 } 
-	soldiers = {
-		culture = telegu
-		religion =  hindu 
-		size = 7210
-	 } 
-	soldiers = {
-		culture = telegu
-		religion = secularism
-		size = 165
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 36050
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion = secularism
-		size = 829
-	 } 
-	bureaucrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 901
-	 } 
-	bureaucrats = {
-		culture = telegu
-		religion = secularism
-		size = 20
-	 } 
-	capitalists = {
-		culture = telegu
-		religion =  hindu 
-		size = 4506
-	 } 
-	capitalists = {
-		culture = telegu
-		religion = secularism
-		size = 103
-	 } 
-	clergymen = {
-		culture = telegu
-		religion =  hindu 
-		size = 9012
-	 } 
-	clergymen = {
-		culture = telegu
-		religion = secularism
-		size = 207
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 10017
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 230
-	 } 
-	farmers = {
-		culture = telegu
-		religion =  hindu 
-		size = 723604
-	 } 
-	farmers = {
-		culture = telegu
-		religion = secularism
-		size = 16655
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 93263
-	 } 
+    officers = {
+        culture = telegu
+        religion = hindu
+        size = 1297
+    }
+
+    officers = {
+        culture = telegu
+        religion = secularism
+        size = 29
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = hindu
+        size = 5191
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = secularism
+        size = 118
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = hindu
+        size = 25956
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = secularism
+        size = 596
+    }
+
+    bureaucrats = {
+        culture = telegu
+        religion = hindu
+        size = 648
+    }
+
+    bureaucrats = {
+        culture = telegu
+        religion = secularism
+        size = 14
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = hindu
+        size = 3244
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = secularism
+        size = 74
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = hindu
+        size = 6488
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = secularism
+        size = 149
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 7212
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 165
+    }
+
+    farmers = {
+        culture = telegu
+        religion = hindu
+        size = 520994
+    }
+
+    farmers = {
+        culture = telegu
+        religion = secularism
+        size = 11991
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 67149
+    }
 }
 #Aurangabad - Maharashtra (6520000/1630000 POPS)
 1284 = {
-	officers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 3260
-	 } 
-	soldiers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 13040
-	 } 
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 65200
-	 } 
-	bureaucrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1630
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 8150
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 16300
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 18118
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 526302
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 925969
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 21313
-	 } 
+    officers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 2347
+    }
+
+    soldiers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 9388
+    }
+
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 46944
+    }
+
+    bureaucrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1173
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5868
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 11736
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 13044
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 378937
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 666697
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15345
+    }
 }
 #Nizamabad - Terangala (6931000/1732750 POPS)
 1285 = {
-	officers = {
-		culture = telegu
-		religion =  hindu 
-		size = 3387
-	 } 
-	officers = {
-		culture = telegu
-		religion = secularism
-		size = 77
-	 } 
-	soldiers = {
-		culture = telegu
-		religion =  hindu 
-		size = 13550
-	 } 
-	soldiers = {
-		culture = telegu
-		religion = secularism
-		size = 311
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 67750
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion = secularism
-		size = 1559
-	 } 
-	bureaucrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 1693
-	 } 
-	bureaucrats = {
-		culture = telegu
-		religion = secularism
-		size = 38
-	 } 
-	capitalists = {
-		culture = telegu
-		religion =  hindu 
-		size = 8468
-	 } 
-	capitalists = {
-		culture = telegu
-		religion = secularism
-		size = 194
-	 } 
-	clergymen = {
-		culture = telegu
-		religion =  hindu 
-		size = 16937
-	 } 
-	clergymen = {
-		culture = telegu
-		religion = secularism
-		size = 389
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 18826
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 433
-	 } 
-	farmers = {
-		culture = telegu
-		religion =  hindu 
-		size = 695600
-	 } 
-	farmers = {
-		culture = telegu
-		religion = secularism
-		size = 695600
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 175274
-	 } 
+    officers = {
+        culture = telegu
+        religion = hindu
+        size = 2438
+    }
+
+    officers = {
+        culture = telegu
+        religion = secularism
+        size = 55
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = hindu
+        size = 9756
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = secularism
+        size = 223
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = hindu
+        size = 48780
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = secularism
+        size = 1122
+    }
+
+    bureaucrats = {
+        culture = telegu
+        religion = hindu
+        size = 1218
+    }
+
+    bureaucrats = {
+        culture = telegu
+        religion = secularism
+        size = 27
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = hindu
+        size = 6096
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = secularism
+        size = 139
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = hindu
+        size = 12194
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = secularism
+        size = 280
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 13554
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 311
+    }
+
+    farmers = {
+        culture = telegu
+        religion = hindu
+        size = 500832
+    }
+
+    farmers = {
+        culture = telegu
+        religion = secularism
+        size = 500832
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 126197
+    }
 }
 #Gulbarga - Gulbarga (4124000/1031000 POPS)
 1286 = {
-	officers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 2062
-	 } 
-	soldiers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 8248
-	 } 
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 41240
-	 } 
-	bureaucrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1031
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 5155
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 10310
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 11460
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 23594
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 888029
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 20440
-	 } 
+    officers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1484
+    }
+
+    soldiers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5938
+    }
+
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 29692
+    }
+
+    bureaucrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 742
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 3711
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 7423
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 8251
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 16987
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 639380
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 14716
+    }
 }
 #Warangal - Terangala (4100000/1025000 POPS)
 1287 = {
-	officers = {
-		culture = telegu
-		religion =  hindu 
-		size = 2003
-	 } 
-	officers = {
-		culture = telegu
-		religion = secularism
-		size = 46
-	 } 
-	soldiers = {
-		culture = telegu
-		religion =  hindu 
-		size = 8015
-	 } 
-	soldiers = {
-		culture = telegu
-		religion = secularism
-		size = 184
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 40077
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion = secularism
-		size = 922
-	 } 
-	bureaucrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 1001
-	 } 
-	bureaucrats = {
-		culture = telegu
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = telegu
-		religion =  hindu 
-		size = 5009
-	 } 
-	capitalists = {
-		culture = telegu
-		religion = secularism
-		size = 115
-	 } 
-	clergymen = {
-		culture = telegu
-		religion =  hindu 
-		size = 10019
-	 } 
-	clergymen = {
-		culture = telegu
-		religion = secularism
-		size = 230
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 11136
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 256
-	 } 
-	farmers = {
-		culture = telegu
-		religion =  hindu 
-		size = 804440
-	 } 
-	farmers = {
-		culture = telegu
-		religion = secularism
-		size = 18516
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 103683
-	 } 
+    officers = {
+        culture = telegu
+        religion = hindu
+        size = 1442
+    }
+
+    officers = {
+        culture = telegu
+        religion = secularism
+        size = 33
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = hindu
+        size = 5770
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = secularism
+        size = 132
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = hindu
+        size = 28855
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = secularism
+        size = 663
+    }
+
+    bureaucrats = {
+        culture = telegu
+        religion = hindu
+        size = 720
+    }
+
+    bureaucrats = {
+        culture = telegu
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = hindu
+        size = 3606
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = secularism
+        size = 82
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = hindu
+        size = 7213
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = secularism
+        size = 165
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 8017
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 184
+    }
+
+    farmers = {
+        culture = telegu
+        religion = hindu
+        size = 579196
+    }
+
+    farmers = {
+        culture = telegu
+        religion = secularism
+        size = 13331
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 74651
+    }
 }

--- a/CWE/history/pops/1946.1.1/Indore.txt
+++ b/CWE/history/pops/1946.1.1/Indore.txt
@@ -1,83 +1,98 @@
 #Indore - Madhya Pradesh (6072000/1518000 POPS)
 1271 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 2967
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 68
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 11870
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 273
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 59353
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1366
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1483
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 34
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7419
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 170
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14838
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 341
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16493
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 379
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 686165
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 686165
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 2136
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 48
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 8546
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 196
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 42734
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 983
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 1067
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 24
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5341
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 122
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10683
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 245
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11874
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 272
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 494038
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 494038
+    }
 }

--- a/CWE/history/pops/1946.1.1/Jammu and Kashmir.txt
+++ b/CWE/history/pops/1946.1.1/Jammu and Kashmir.txt
@@ -1,122 +1,140 @@
 #Srinagar - Srinagar (3098000/774500 POPS)
 1224 = {
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 30980
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 3872
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 7745
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 14086
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 461458
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 202069
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 2041
-	 } 
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 22305
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 2787
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5576
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10141
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 332249
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 145489
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 1469
+    }
 }
 #Gilgit - Gilgit (1992000/498000 POPS)
 1225 = {
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 19920
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 2490
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 4980
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 9057
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 137355
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 290603
-	 } 
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 14342
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1792
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 3585
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 6521
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 98895
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 209234
+    }
 }
 #Leh - Leh (73000/18250 POPS)
 1226 = {
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 7408
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1084
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 10
-	 } 
-	farmers = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 7108
-	 } 
-	farmers = {
-		culture = tibetan
-		religion = secularism
-		size = 71
-	 } 
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5333
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 780
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 7
+    }
+
+    farmers = {
+        culture = tibetan
+        religion = buddhist
+        size = 5117
+    }
+
+    farmers = {
+        culture = tibetan
+        religion = secularism
+        size = 51
+    }
 }
 #Aksai Chin - Aksai Chin (112000/28000 POPS)
 3281 = {
-	aristocrats = {
-		culture = uighur
-		religion =  sunni 
-		size = 1120
-	 } 
-	farmers = {
-		culture = uighur
-		religion =  sunni 
-		size = 21358
-	 } 
-	farmers = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 4116
-	 } 
-	farmers = {
-		culture = tibetan
-		religion = secularism
-		size = 94
-	 } 
+    aristocrats = {
+        culture = uighur
+        religion = sunni
+        size = 806
+    }
+
+    farmers = {
+        culture = uighur
+        religion = sunni
+        size = 15377
+    }
+
+    farmers = {
+        culture = tibetan
+        religion = buddhist
+        size = 2963
+    }
+
+    farmers = {
+        culture = tibetan
+        religion = secularism
+        size = 67
+    }
 }

--- a/CWE/history/pops/1946.1.1/Manipur.txt
+++ b/CWE/history/pops/1946.1.1/Manipur.txt
@@ -1,98 +1,116 @@
 #Imphal - Manipur (1826000/456500 POPS)
 1259 = {
-	officers = {
-		culture = manupur
-		religion =  hindu 
-		size = 892
-	 } 
-	officers = {
-		culture = manupur
-		religion = secularism
-		size = 20
-	 } 
-	soldiers = {
-		culture = manupur
-		religion =  hindu 
-		size = 3569
-	 } 
-	soldiers = {
-		culture = manupur
-		religion = secularism
-		size = 82
-	 } 
-	aristocrats = {
-		culture = manupur
-		religion =  hindu 
-		size = 17849
-	 } 
-	aristocrats = {
-		culture = manupur
-		religion = secularism
-		size = 410
-	 } 
-	bureaucrats = {
-		culture = manupur
-		religion =  hindu 
-		size = 445
-	 } 
-	bureaucrats = {
-		culture = manupur
-		religion = secularism
-		size = 10
-	 } 
-	capitalists = {
-		culture = manupur
-		religion =  hindu 
-		size = 2230
-	 } 
-	capitalists = {
-		culture = manupur
-		religion = secularism
-		size = 51
-	 } 
-	clergymen = {
-		culture = manupur
-		religion =  hindu 
-		size = 4462
-	 } 
-	clergymen = {
-		culture = manupur
-		religion = secularism
-		size = 102
-	 } 
-	artisans = {
-		culture = manupur
-		religion =  hindu 
-		size = 4959
-	 } 
-	artisans = {
-		culture = manupur
-		religion = secularism
-		size = 114
-	 } 
-	farmers = {
-		culture = manupur
-		religion =  hindu 
-		size = 211015
-	 } 
-	farmers = {
-		culture = manupur
-		religion = secularism
-		size = 4857
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 22825
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 170080
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion = secularism
-		size = 3914
-	 } 
+    officers = {
+        culture = manupur
+        religion = hindu
+        size = 642
+    }
+
+    officers = {
+        culture = manupur
+        religion = secularism
+        size = 14
+    }
+
+    soldiers = {
+        culture = manupur
+        religion = hindu
+        size = 2569
+    }
+
+    soldiers = {
+        culture = manupur
+        religion = secularism
+        size = 59
+    }
+
+    aristocrats = {
+        culture = manupur
+        religion = hindu
+        size = 12851
+    }
+
+    aristocrats = {
+        culture = manupur
+        religion = secularism
+        size = 295
+    }
+
+    bureaucrats = {
+        culture = manupur
+        religion = hindu
+        size = 320
+    }
+
+    bureaucrats = {
+        culture = manupur
+        religion = secularism
+        size = 7
+    }
+
+    capitalists = {
+        culture = manupur
+        religion = hindu
+        size = 1605
+    }
+
+    capitalists = {
+        culture = manupur
+        religion = secularism
+        size = 36
+    }
+
+    clergymen = {
+        culture = manupur
+        religion = hindu
+        size = 3212
+    }
+
+    clergymen = {
+        culture = manupur
+        religion = secularism
+        size = 73
+    }
+
+    artisans = {
+        culture = manupur
+        religion = hindu
+        size = 3570
+    }
+
+    artisans = {
+        culture = manupur
+        religion = secularism
+        size = 82
+    }
+
+    farmers = {
+        culture = manupur
+        religion = hindu
+        size = 151930
+    }
+
+    farmers = {
+        culture = manupur
+        religion = secularism
+        size = 3497
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 16434
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = protestant
+        size = 122457
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = secularism
+        size = 2818
+    }
 }

--- a/CWE/history/pops/1946.1.1/Mysore.txt
+++ b/CWE/history/pops/1946.1.1/Mysore.txt
@@ -1,292 +1,344 @@
 #Bratsk - Tumkuru (4182000/1045500 POPS)
 1076 = {
-	officers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 2091
-	 } 
-	soldiers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 8364
-	 } 
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 41820
-	 } 
-	bureaucrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1045
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 5227
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 10455
-	 } 
-	clerks = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 12233
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 11621
-	 } 
-	craftsmen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 37310
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 78934
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 115005
-	 } 
-	farmers = {
-		culture = kannada
-		religion =  hindu 
-		size = 705163
-	 } 
-	farmers = {
-		culture = kannada
-		religion = secularism
-		size = 16231
-	 } 
+    officers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1505
+    }
+
+    soldiers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 6022
+    }
+
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 30110
+    }
+
+    bureaucrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 752
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 3763
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 7527
+    }
+
+    clerks = {
+        culture = indian_muslim
+        religion = sunni
+        size = 8807
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 8367
+    }
+
+    craftsmen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 26863
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 56832
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 82803
+    }
+
+    farmers = {
+        culture = kannada
+        religion = hindu
+        size = 507717
+    }
+
+    farmers = {
+        culture = kannada
+        religion = secularism
+        size = 11686
+    }
 }
 #Bangalore - Bangalore (5669000/1417250 POPS)
 1313 = {
-	officers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 2834
-	 } 
-	soldiers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 11338
-	 } 
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 56690
-	 } 
-	bureaucrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1417
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 7086
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 14172
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 15753
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 174160
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 155897
-	 } 
-	farmers = {
-		culture = kannada
-		religion =  hindu 
-		size = 929791
-	 } 
-	farmers = {
-		culture = kannada
-		religion = secularism
-		size = 21401
-	 } 
+    officers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 2040
+    }
+
+    soldiers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 8163
+    }
+
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 40816
+    }
+
+    bureaucrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1020
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5101
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10203
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 11342
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 125395
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 112245
+    }
+
+    farmers = {
+        culture = kannada
+        religion = hindu
+        size = 669449
+    }
+
+    farmers = {
+        culture = kannada
+        religion = secularism
+        size = 15408
+    }
 }
 #Mysore - Mysore (3442000/860500 POPS)
 1314 = {
-	officers = {
-		culture = kannada
-		religion =  hindu 
-		size = 1682
-	 } 
-	officers = {
-		culture = kannada
-		religion = secularism
-		size = 38
-	 } 
-	soldiers = {
-		culture = kannada
-		religion =  hindu 
-		size = 6729
-	 } 
-	soldiers = {
-		culture = kannada
-		religion = secularism
-		size = 154
-	 } 
-	aristocrats = {
-		culture = kannada
-		religion =  hindu 
-		size = 33645
-	 } 
-	aristocrats = {
-		culture = kannada
-		religion = secularism
-		size = 774
-	 } 
-	bureaucrats = {
-		culture = kannada
-		religion =  hindu 
-		size = 840
-	 } 
-	bureaucrats = {
-		culture = kannada
-		religion = secularism
-		size = 19
-	 } 
-	capitalists = {
-		culture = kannada
-		religion =  hindu 
-		size = 4205
-	 } 
-	capitalists = {
-		culture = kannada
-		religion = secularism
-		size = 96
-	 } 
-	clergymen = {
-		culture = kannada
-		religion =  hindu 
-		size = 8411
-	 } 
-	clergymen = {
-		culture = kannada
-		religion = secularism
-		size = 193
-	 } 
-	artisans = {
-		culture = kannada
-		religion =  hindu 
-		size = 9348
-	 } 
-	artisans = {
-		culture = kannada
-		religion = secularism
-		size = 215
-	 } 
-	farmers = {
-		culture = kannada
-		religion =  hindu 
-		size = 760422
-	 } 
-	farmers = {
-		culture = kannada
-		religion = secularism
-		size = 17503
-	 } 
+    officers = {
+        culture = kannada
+        religion = hindu
+        size = 1211
+    }
+
+    officers = {
+        culture = kannada
+        religion = secularism
+        size = 27
+    }
+
+    soldiers = {
+        culture = kannada
+        religion = hindu
+        size = 4844
+    }
+
+    soldiers = {
+        culture = kannada
+        religion = secularism
+        size = 110
+    }
+
+    aristocrats = {
+        culture = kannada
+        religion = hindu
+        size = 24224
+    }
+
+    aristocrats = {
+        culture = kannada
+        religion = secularism
+        size = 557
+    }
+
+    bureaucrats = {
+        culture = kannada
+        religion = hindu
+        size = 604
+    }
+
+    bureaucrats = {
+        culture = kannada
+        religion = secularism
+        size = 13
+    }
+
+    capitalists = {
+        culture = kannada
+        religion = hindu
+        size = 3027
+    }
+
+    capitalists = {
+        culture = kannada
+        religion = secularism
+        size = 69
+    }
+
+    clergymen = {
+        culture = kannada
+        religion = hindu
+        size = 6055
+    }
+
+    clergymen = {
+        culture = kannada
+        religion = secularism
+        size = 138
+    }
+
+    artisans = {
+        culture = kannada
+        religion = hindu
+        size = 6730
+    }
+
+    artisans = {
+        culture = kannada
+        religion = secularism
+        size = 154
+    }
+
+    farmers = {
+        culture = kannada
+        religion = hindu
+        size = 547503
+    }
+
+    farmers = {
+        culture = kannada
+        religion = secularism
+        size = 12602
+    }
 }
 #Chitaldroog - Chitaldroog (1435000/358750 POPS)
 1315 = {
-	officers = {
-		culture = kannada
-		religion =  hindu 
-		size = 700
-	 } 
-	officers = {
-		culture = kannada
-		religion = secularism
-		size = 16
-	 } 
-	soldiers = {
-		culture = kannada
-		religion =  hindu 
-		size = 2805
-	 } 
-	soldiers = {
-		culture = kannada
-		religion = secularism
-		size = 64
-	 } 
-	aristocrats = {
-		culture = kannada
-		religion =  hindu 
-		size = 14027
-	 } 
-	aristocrats = {
-		culture = kannada
-		religion = secularism
-		size = 322
-	 } 
-	bureaucrats = {
-		culture = kannada
-		religion =  hindu 
-		size = 349
-	 } 
-	bureaucrats = {
-		culture = kannada
-		religion = secularism
-		size = 8
-	 } 
-	capitalists = {
-		culture = kannada
-		religion =  hindu 
-		size = 1752
-	 } 
-	capitalists = {
-		culture = kannada
-		religion = secularism
-		size = 40
-	 } 
-	clergymen = {
-		culture = kannada
-		religion =  hindu 
-		size = 3506
-	 } 
-	clergymen = {
-		culture = kannada
-		religion = secularism
-		size = 80
-	 } 
-	artisans = {
-		culture = kannada
-		religion =  hindu 
-		size = 3897
-	 } 
-	artisans = {
-		culture = kannada
-		religion = secularism
-		size = 89
-	 } 
-	farmers = {
-		culture = kannada
-		religion =  hindu 
-		size = 317026
-	 } 
-	farmers = {
-		culture = kannada
-		religion = secularism
-		size = 7297
-	 } 
+    officers = {
+        culture = kannada
+        religion = hindu
+        size = 504
+    }
+
+    officers = {
+        culture = kannada
+        religion = secularism
+        size = 11
+    }
+
+    soldiers = {
+        culture = kannada
+        religion = hindu
+        size = 2019
+    }
+
+    soldiers = {
+        culture = kannada
+        religion = secularism
+        size = 46
+    }
+
+    aristocrats = {
+        culture = kannada
+        religion = hindu
+        size = 10099
+    }
+
+    aristocrats = {
+        culture = kannada
+        religion = secularism
+        size = 231
+    }
+
+    bureaucrats = {
+        culture = kannada
+        religion = hindu
+        size = 251
+    }
+
+    bureaucrats = {
+        culture = kannada
+        religion = secularism
+        size = 5
+    }
+
+    capitalists = {
+        culture = kannada
+        religion = hindu
+        size = 1261
+    }
+
+    capitalists = {
+        culture = kannada
+        religion = secularism
+        size = 28
+    }
+
+    clergymen = {
+        culture = kannada
+        religion = hindu
+        size = 2524
+    }
+
+    clergymen = {
+        culture = kannada
+        religion = secularism
+        size = 57
+    }
+
+    artisans = {
+        culture = kannada
+        religion = hindu
+        size = 2805
+    }
+
+    artisans = {
+        culture = kannada
+        religion = secularism
+        size = 64
+    }
+
+    farmers = {
+        culture = kannada
+        religion = hindu
+        size = 228258
+    }
+
+    farmers = {
+        culture = kannada
+        religion = secularism
+        size = 5253
+    }
 }

--- a/CWE/history/pops/1946.1.1/Naxalite India.txt
+++ b/CWE/history/pops/1946.1.1/Naxalite India.txt
@@ -1,259 +1,306 @@
 #Chhatarpur - Bundelkhand (1147000/286750 POPS)
 1273 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 560
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 12
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 2242
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 51
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 11211
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 258
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 279
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 1400
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 2802
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 64
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 3115
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 71
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 239064
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 5502
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 14666
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 403
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 1614
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 36
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 8071
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 185
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 200
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 1008
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 2017
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 46
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 2242
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 51
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 172126
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 3961
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10559
+    }
 }
 #Rewali - Bundelkhand (1147000/286750 POPS)
 1274 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 560
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 12
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 2242
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 51
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 11211
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 258
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 279
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 1400
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 2802
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 64
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 3115
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 71
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 239064
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 5502
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 14666
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 403
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 1614
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 36
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 8071
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 185
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 200
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 1008
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 2017
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 46
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 2242
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 51
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 172126
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 3961
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10559
+    }
 }
 #Raigarh - Chhattisgarh (2671000/667750 POPS)
 1282 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 1304
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 30
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 5221
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 120
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 26109
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 600
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 651
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 15
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3262
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 75
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 6526
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 150
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 7255
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 166
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 590089
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 13582
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 938
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 21
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 3759
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 86
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 18798
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 432
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 468
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2348
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 54
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 4698
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 108
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 5223
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 119
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 424864
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 9779
+    }
 }

--- a/CWE/history/pops/1946.1.1/Orissa.txt
+++ b/CWE/history/pops/1946.1.1/Orissa.txt
@@ -1,166 +1,196 @@
 #Keunjahr - Orissa (5848000/1462000 POPS)
 1262 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 4287
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 98
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 17149
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 394
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 57164
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1315
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1429
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7145
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 164
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14291
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 328
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 15805
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 363
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1285441
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 29588
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 3086
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 70
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 12347
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 283
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41158
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 946
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 1028
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5144
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 118
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10289
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 236
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11379
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 261
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 925517
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 21303
+    }
 }
 #Sambalpur - Orissa (5848000/1462000 POPS)
 1263 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 4287
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 98
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 17149
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 394
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 57164
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1315
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1429
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7145
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 164
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14291
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 328
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 15805
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 363
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1285441
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 29588
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 3086
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 70
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 12347
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 283
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41158
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 946
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 1028
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5144
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 118
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10289
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 236
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11379
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 261
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 925517
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 21303
+    }
 }

--- a/CWE/history/pops/1946.1.1/Portugal.txt
+++ b/CWE/history/pops/1946.1.1/Portugal.txt
@@ -1,100 +1,118 @@
 #Goa - Goa (609000/152250 POPS)
 1303 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 445
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 10
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1785
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 41
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 5952
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 137
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 148
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 3
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 743
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 17
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 1487
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 34
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1645
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 37
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 87501
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 2014
-	 } 
-	farmers = {
-		culture = goan
-		religion =  catholic 
-		size = 38694
-	 } 
-	farmers = {
-		culture = goan
-		religion = secularism
-		size = 890
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 7845
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 320
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 7
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 1285
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 29
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 4285
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 98
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 106
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 534
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 1070
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 24
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1184
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 26
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 63000
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 1450
+    }
+
+    farmers = {
+        culture = goan
+        religion = catholic
+        size = 27859
+    }
+
+    farmers = {
+        culture = goan
+        religion = secularism
+        size = 640
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5648
+    }
 }
 #Dili - Dili (436000/109000 POPS)
 1446 = {

--- a/CWE/history/pops/1946.1.1/Raj.txt
+++ b/CWE/history/pops/1946.1.1/Raj.txt
@@ -1,8514 +1,10052 @@
 #Vilyuysk - Faizabad (4182000/1045500 POPS)
 1069 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 204
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 817
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 40879
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 940
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1021
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5109
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 117
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10219
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 235
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11462
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 263
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 788746
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 18155
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 146865
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 146
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 588
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 29432
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 676
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 735
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3678
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7357
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 169
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8252
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 189
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 567897
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 13071
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 105742
+    }
 }
 #Bryanka - Sylhet (2963000/740750 POPS)
 1070 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 143
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 574
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 17
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 28741
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 888
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 717
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 22
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 3591
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 111
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 7184
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 222
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 7312
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 226
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 81068
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 2507
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 598132
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 143
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 574
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 17
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 28741
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 888
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 717
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 22
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 3591
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 111
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 7184
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 222
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 7312
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 226
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 81068
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 2507
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 598132
+    }
 }
 #Bytantaysk - Mirzapur (4182000/1045500 POPS)
 1071 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 204
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 817
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 40879
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 940
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1021
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5109
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 117
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10219
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 235
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11462
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 263
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 788746
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 18155
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 146865
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 146
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 588
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 29432
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 676
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 735
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3678
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7357
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 169
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8252
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 189
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 567897
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 13071
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 105742
+    }
 }
 #Peshawar - Peshawar (4753000/1188250 POPS)
 1218 = {
-	aristocrats = {
-		culture = pashtun
-		religion =  sunni 
-		size = 47530
-	 } 
-	artisans = {
-		culture = pashtun
-		religion =  sunni 
-		size = 1188
-	 } 
-	capitalists = {
-		culture = pashtun
-		religion =  sunni 
-		size = 5941
-	 } 
-	clergymen = {
-		culture = pashtun
-		religion =  sunni 
-		size = 11882
-	 } 
-	artisans = {
-		culture = pashtun
-		religion =  sunni 
-		size = 15414
-	 } 
-	farmers = {
-		culture = pashtun
-		religion =  sunni 
-		size = 926870
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 140986
-	 } 
+    aristocrats = {
+        culture = pashtun
+        religion = sunni
+        size = 47530
+    }
+
+    artisans = {
+        culture = pashtun
+        religion = sunni
+        size = 1188
+    }
+
+    capitalists = {
+        culture = pashtun
+        religion = sunni
+        size = 5941
+    }
+
+    clergymen = {
+        culture = pashtun
+        religion = sunni
+        size = 11882
+    }
+
+    artisans = {
+        culture = pashtun
+        religion = sunni
+        size = 15414
+    }
+
+    farmers = {
+        culture = pashtun
+        religion = sunni
+        size = 926870
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 140986
+    }
 }
 #Quetta - Quetta (874000/218500 POPS)
 1219 = {
-	aristocrats = {
-		culture = pashtun
-		religion =  sunni 
-		size = 8740
-	 } 
-	capitalists = {
-		culture = pashtun
-		religion =  sunni 
-		size = 1092
-	 } 
-	clergymen = {
-		culture = pashtun
-		religion =  sunni 
-		size = 2185
-	 } 
-	artisans = {
-		culture = pashtun
-		religion =  sunni 
-		size = 2834
-	 } 
-	farmers = {
-		culture = pashtun
-		religion =  sunni 
-		size = 196363
-	 } 
+    aristocrats = {
+        culture = pashtun
+        religion = sunni
+        size = 8740
+    }
+
+    capitalists = {
+        culture = pashtun
+        religion = sunni
+        size = 1092
+    }
+
+    clergymen = {
+        culture = pashtun
+        religion = sunni
+        size = 2185
+    }
+
+    artisans = {
+        culture = pashtun
+        religion = sunni
+        size = 2834
+    }
+
+    farmers = {
+        culture = pashtun
+        religion = sunni
+        size = 196363
+    }
 }
 #Chitral - Chitral (980000/245000 POPS)
 1223 = {
-	aristocrats = {
-		culture = pashtun
-		religion =  sunni 
-		size = 9800
-	 } 
-	capitalists = {
-		culture = pashtun
-		religion =  sunni 
-		size = 1225
-	 } 
-	clergymen = {
-		culture = pashtun
-		religion =  sunni 
-		size = 2450
-	 } 
-	artisans = {
-		culture = pashtun
-		religion =  sunni 
-		size = 3178
-	 } 
-	farmers = {
-		culture = pashtun
-		religion =  sunni 
-		size = 220175
-	 } 
+    aristocrats = {
+        culture = pashtun
+        religion = sunni
+        size = 9800
+    }
+
+    capitalists = {
+        culture = pashtun
+        religion = sunni
+        size = 1225
+    }
+
+    clergymen = {
+        culture = pashtun
+        religion = sunni
+        size = 2450
+    }
+
+    artisans = {
+        culture = pashtun
+        religion = sunni
+        size = 3178
+    }
+
+    farmers = {
+        culture = pashtun
+        religion = sunni
+        size = 220175
+    }
 }
 #Lahore - Lahore (4072000/1018000 POPS)
 1227 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 200
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 2
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 805
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 8
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 29227
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 295
-	 } 
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 11197
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1018
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 5090
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 10180
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 13206
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 743169
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 171687
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 200
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 805
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 29227
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 295
+    }
+
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 11197
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1018
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5090
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10180
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 13206
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 743169
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 171687
+    }
 }
 #Multan - Multan (3498000/874500 POPS)
 1228 = {
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 34980
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 4372
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 8745
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 11344
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 785896
-	 } 
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 34980
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 4372
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 8745
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 11344
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 785896
+    }
 }
 #Sialkot - Sialkot (3693000/923250 POPS)
 1229 = {
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 36930
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 4616
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 9232
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 11977
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 655535
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 174171
-	 } 
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 36930
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 4616
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 9232
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 11977
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 655535
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 174171
+    }
 }
 #Attock - Attock (2119000/529750 POPS)
 1230 = {
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 21190
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 2648
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 5297
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 6872
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 476077
-	 } 
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 21190
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 2648
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5297
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 6872
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 476077
+    }
 }
 #Bahawalpur - Bahawalpur (2431000/607750 POPS)
 1231 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 119
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 1
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 481
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 24066
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 243
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 600
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3007
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 30
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 6016
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 60
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 7805
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 78
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 18069
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 182
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 527920
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 119
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 481
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 24066
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 243
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 600
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 6
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3007
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 30
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 6016
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 60
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 7805
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 78
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 18069
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 182
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 527920
+    }
 }
 #Shahpur - Shahpur (3252000/813000 POPS)
 1232 = {
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 32520
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 4065
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 8130
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 10546
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 730626
-	 } 
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 32520
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 4065
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 8130
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10546
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 730626
+    }
 }
 #Amritsar - Punjab (5793000/1448250 POPS)
 1233 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 282
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1131
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 56626
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1303
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1415
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7078
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 162
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14156
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 325
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 15878
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 365
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 469696
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 10811
-	 } 
-	farmers = {
-		culture = sikh
-		religion =  sikh 
-		size = 821755
-	 } 
-	farmers = {
-		culture = sikh
-		religion = secularism
-		size = 18915
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 203
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 814
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 40770
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 938
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1018
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5096
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 116
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10192
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 234
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11432
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 262
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 338181
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 7783
+    }
+
+    farmers = {
+        culture = sikh
+        religion = sikh
+        size = 591663
+    }
+
+    farmers = {
+        culture = sikh
+        religion = secularism
+        size = 13618
+    }
 }
 #Firuzapur - Punjab (5793000/1448250 POPS)
 1234 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 282
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1131
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 56626
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1303
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1415
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7078
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 162
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14156
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 325
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 15878
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 365
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 469696
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 10811
-	 } 
-	farmers = {
-		culture = sikh
-		religion =  sikh 
-		size = 821755
-	 } 
-	farmers = {
-		culture = sikh
-		religion = secularism
-		size = 18915
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 203
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 814
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 40770
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 938
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1018
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5096
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 116
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10192
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 234
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11432
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 262
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 338181
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 7783
+    }
+
+    farmers = {
+        culture = sikh
+        religion = sikh
+        size = 591663
+    }
+
+    farmers = {
+        culture = sikh
+        religion = secularism
+        size = 13618
+    }
 }
 #Simla - Himachal Pradesh (2867000/716750 POPS)
 1235 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 139
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 3
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 560
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 12
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 28024
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 645
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 699
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 16
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3502
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 80
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 7005
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 161
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 7858
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 180
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 639150
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 14711
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 100
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 403
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 20177
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 464
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 503
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 11
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2521
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 57
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 5043
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 115
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 5657
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 129
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 460188
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 10591
+    }
 }
 #Delhi - Delhi (4603000/1150750 POPS)
 1236 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 224
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 160000
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 899
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 20
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 44994
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 44994
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1035
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1124
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 25
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5623
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 129
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 11248
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 258
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 12616
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 290
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 823155
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 18947
-	 } 
-	craftsmen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 172612
-	 } 
-	farmers = {
-		culture = sikh
-		religion =  sikh 
-		size = 34277
-	 } 
-	farmers = {
-		culture = sikh
-		religion = secularism
-		size = 789
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 161
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 115200
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 647
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 14
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 32395
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 32395
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 745
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 809
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4048
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 92
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8098
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 185
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9083
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 208
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 592671
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 13641
+    }
+
+    craftsmen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 124280
+    }
+
+    farmers = {
+        culture = sikh
+        religion = sikh
+        size = 24679
+    }
+
+    farmers = {
+        culture = sikh
+        religion = secularism
+        size = 568
+    }
 }
 #Panipat - Panipat (5301000/1325250 POPS)
 1237 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 259
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1036
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 51817
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1192
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1295
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 29
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6476
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 149
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 12953
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 298
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 14529
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 334
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1051612
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 24205
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 79515
-	 } 
-	farmers = {
-		culture = sikh
-		religion =  sikh 
-		size = 52431
-	 } 
-	farmers = {
-		culture = sikh
-		religion = secularism
-		size = 1206
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 186
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 745
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 37308
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 858
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 932
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4662
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 107
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 9326
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 214
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 10460
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 240
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 757160
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 17427
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 57250
+    }
+
+    farmers = {
+        culture = sikh
+        religion = sikh
+        size = 37750
+    }
+
+    farmers = {
+        culture = sikh
+        religion = secularism
+        size = 868
+    }
 }
 #Dehra Dun - Uttarakhand (4231000/1057750 POPS)
 1238 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 206
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 826
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 19
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 41358
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 951
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1033
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5169
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 118
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10339
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 237
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11597
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 266
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 839346
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 19320
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 106275
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 148
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 594
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 13
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 29777
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 684
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 743
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3721
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7444
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 170
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8349
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 191
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 604329
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 13910
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 76518
+    }
 }
 #Meerut - Western Uttar Pradesh (5826000/1456500 POPS)
 1239 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 284
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1138
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 56949
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1310
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1423
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7118
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 163
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14237
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 327
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 15969
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 367
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 956438
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 22015
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 350251
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 204
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 819
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41003
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 943
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1024
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5124
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 117
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10250
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 235
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11497
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 264
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 688635
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15850
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 252180
+    }
 }
 #Agra - Western Uttar Pradesh (6273000/1568250 POPS)
 1240 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 305
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 7
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1225
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 28
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 61318
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1411
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1532
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 35
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7664
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 176
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 15329
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 352
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 17194
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 395
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1029822
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 23704
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 377122
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 219
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 5
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 882
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 44148
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 1015
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1103
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 25
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5518
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 126
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 11036
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 253
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 12379
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 284
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 741471
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 17066
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 271527
+    }
 }
 #Cawnpore - Bundelkhand (1147000/286750 POPS)
 1241 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 55
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 1
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 223
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 11211
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 258
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 279
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 1400
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 2802
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 64
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 3143
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 72
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 241558
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 5560
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 14471
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 39
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 0
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 160
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 8071
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 185
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 200
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 1008
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 2017
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 46
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 2262
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 51
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 173921
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 4003
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10419
+    }
 }
 #Lucknow - Awadh Uttar Pradesh (4346000/1086500 POPS)
 1242 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 212
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 849
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 19
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 42482
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 977
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1061
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 24
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5309
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 122
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10620
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 244
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11911
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 274
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 734713
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 16911
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 152110
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 87434
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 152
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 611
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 13
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 30587
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 703
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 763
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 17
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3822
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 87
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7646
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 175
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8575
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 197
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 528993
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 12175
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 109519
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 62952
+    }
 }
 #Allahabad - Purvanchal (5371000/1342750 POPS)
 1243 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 261
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1049
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 24
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 52501
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1208
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1311
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 30
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6561
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 151
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 13124
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 302
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 14722
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 338
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1012997
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 23317
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 188620
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 187
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 755
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 17
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 37800
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 869
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 943
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 21
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4723
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 108
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 9449
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 217
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 10599
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 243
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 729357
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 16788
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 135806
+    }
 }
 #Fyzabad - Awadh Uttar Pradesh (4501000/1125250 POPS)
 1244 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 219
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 879
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 20
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 43997
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1012
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1099
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 25
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5499
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 126
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10998
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 253
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 12337
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 283
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 760916
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 17514
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 157535
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 90552
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 157
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 632
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 14
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 31677
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 728
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 791
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3959
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 90
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7918
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 182
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8882
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 203
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 547859
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 12610
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 113425
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 65197
+    }
 }
 #Benares - Purvanchal (5371000/1342750 POPS)
 1245 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 261
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1049
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 24
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 52501
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1208
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1311
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 30
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6561
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 151
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 13124
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 302
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 14722
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 338
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1012997
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 23317
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 188620
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 187
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 755
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 17
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 37800
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 869
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 943
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 21
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4723
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 108
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 9449
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 217
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 10599
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 243
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 729357
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 16788
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 135806
+    }
 }
 #Gorakhpur - Purvanchal (5371000/1342750 POPS)
 1246 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 261
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1049
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 24
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 52501
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1208
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1311
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 30
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6561
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 151
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 13124
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 302
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 14722
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 338
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1012997
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 23317
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 80565
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 108055
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 187
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 755
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 17
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 37800
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 869
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 943
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 21
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4723
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 108
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 9449
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 217
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 10599
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 243
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 729357
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 16788
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 58006
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 77799
+    }
 }
 #Patna - Bihar (7946000/1986500 POPS)
 1247 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 388
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 8
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1553
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 35
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 77672
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1787
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1941
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 44
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 9708
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 223
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 19418
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 446
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 21780
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 501
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 756641
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 756641
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 238380
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 60536
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 279
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 5
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 1118
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 25
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 55923
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 1286
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1397
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 31
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 6989
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 160
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 13980
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 321
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 15681
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 360
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 544781
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 544781
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 171633
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 43585
+    }
 }
 #Gaya - Kolhan (4600000/1150000 POPS)
 1248 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 224
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 899
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 20
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 44965
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1035
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1124
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 25
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5620
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 129
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 11241
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 258
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 12608
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 290
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1025491
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 23604
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 161
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 647
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 14
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 32374
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 745
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 809
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4046
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 92
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8093
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 185
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9077
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 208
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 738353
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 16994
+    }
 }
 #Kharswari - Jharkhand (5892000/1473000 POPS)
 1249 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 287
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1151
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 57594
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1325
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1439
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 33
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7199
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 165
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14398
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 331
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16150
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 371
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1111259
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 25578
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 206919
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 206
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 828
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41467
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 954
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1036
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5183
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 118
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10366
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 238
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11628
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 267
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 800106
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 18416
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 148981
+    }
 }
 #Bhagalpur - Bihar (6692000/1673000 POPS)
 1250 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 326
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 7
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1307
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 30
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 65414
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1505
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1635
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 37
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 8176
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 188
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 16353
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 376
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 18342
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 422
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1245789
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 28675
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 251743
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 234
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 5
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 941
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 21
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 47098
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 1083
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1177
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 26
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5886
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 135
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 11774
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 270
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 13206
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 303
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 896968
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 20646
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 181254
+    }
 }
 #Calcutta - West Bengal (8067000/2016750 POPS)
 1251 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 393
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 9
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1576
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 36
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 78854
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1815
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1970
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 45
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 9856
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 226
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 19713
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 453
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 22112
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 508
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 788331
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 788331
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 263133
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 282
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 6
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1134
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 25
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 56774
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1306
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1418
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 32
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 7096
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 162
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 14193
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 326
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 15920
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 365
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 567598
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 567598
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 189455
+    }
 }
 #Darjeeling - West Bengal (6484000/1621000 POPS)
 1252 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 316
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 7
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1266
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 29
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 63381
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1458
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1584
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 36
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7922
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 182
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 15845
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 364
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 17772
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 409
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 256351
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 5900
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 475358
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 10941
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 648400
-	 } 
-	farmers = {
-		culture = nepali
-		religion =  hindu 
-		size = 79977
-	 } 
-	farmers = {
-		culture = nepali
-		religion = secularism
-		size = 1840
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 227
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 5
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 911
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 45634
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 1049
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1140
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 25
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5703
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 131
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 11408
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 262
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 12795
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 294
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 184572
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 4248
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 342257
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 7877
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 466848
+    }
+
+    farmers = {
+        culture = nepali
+        religion = hindu
+        size = 57583
+    }
+
+    farmers = {
+        culture = nepali
+        religion = secularism
+        size = 1324
+    }
 }
 #Bardwan - West Bengal (6088000/1522000 POPS)
 1253 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 297
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1189
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 27
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 59510
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1369
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1487
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 34
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 7438
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 171
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 14877
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 342
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 16686
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 384
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 865552
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 19923
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 502982
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 213
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 856
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 19
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 42847
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 985
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1070
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 24
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 5355
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 123
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 10711
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 246
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 12013
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 276
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 623197
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 14344
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 362147
+    }
 }
 #Dacca - Dhaka, Sylhet (6321000/1580250 POPS)
 1254 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 306
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 9
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1226
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 37
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 61313
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1896
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1532
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 47
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 7663
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 237
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 15327
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 474
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 15599
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 482
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 50313
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1556
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 722249
-	 } 
-	farmers = {
-		culture = bengali
-		religion = secularism
-		size = 722249
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 306
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 9
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1226
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 37
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 61313
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1896
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1532
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 47
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 7663
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 237
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 15327
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 474
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 15599
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 482
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 50313
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1556
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 722249
+    }
+
+    farmers = {
+        culture = bengali
+        religion = secularism
+        size = 722249
+    }
 }
 #Rajshahi - Rajshahi, Rangpur (6599000/1649750 POPS)
 1255 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 319
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 9
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1279
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 39
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 64010
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1979
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1599
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 49
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 8000
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 247
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 16002
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 494
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 16286
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 503
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 212554
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 6573
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 1299130
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 319
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 9
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1279
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 39
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 64010
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1979
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1599
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 49
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 8000
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 247
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 16002
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 494
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 16286
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 503
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 212554
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 6573
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 1299130
+    }
 }
 #Jessore - Khulna, Barisal (4744000/1186000 POPS)
 1256 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 229
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 7
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 919
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 28
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 46016
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1423
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1150
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 35
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 5752
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 177
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 11504
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 355
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 11707
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 362
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 210324
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 6504
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 874641
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 229
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 7
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 919
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 28
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 46016
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1423
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1150
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 35
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 5752
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 177
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 11504
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 355
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 11707
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 362
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 210324
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 6504
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 874641
+    }
 }
 #Chittagong - Chittagong (5037000/1259250 POPS)
 1257 = {
-	soldiers = {
-		culture = bengali
-		religion =  sunni 
-		size = 1007
-	 } 
-	aristocrats = {
-		culture = bengali
-		religion =  sunni 
-		size = 50370
-	 } 
-	artisans = {
-		culture = bengali
-		religion =  sunni 
-		size = 1259
-	 } 
-	capitalists = {
-		culture = bengali
-		religion =  sunni 
-		size = 6296
-	 } 
-	clergymen = {
-		culture = bengali
-		religion =  sunni 
-		size = 12592
-	 } 
-	artisans = {
-		culture = bengali
-		religion =  sunni 
-		size = 12815
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 1149475
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 9125
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 282
-	 } 
+    soldiers = {
+        culture = bengali
+        religion = sunni
+        size = 1007
+    }
+
+    aristocrats = {
+        culture = bengali
+        religion = sunni
+        size = 50370
+    }
+
+    artisans = {
+        culture = bengali
+        religion = sunni
+        size = 1259
+    }
+
+    capitalists = {
+        culture = bengali
+        religion = sunni
+        size = 6296
+    }
+
+    clergymen = {
+        culture = bengali
+        religion = sunni
+        size = 12592
+    }
+
+    artisans = {
+        culture = bengali
+        religion = sunni
+        size = 12815
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 1149475
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 9125
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 282
+    }
 }
 #Gauhati - Meghalaya (1239000/309750 POPS)
 1258 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 59
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 1
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 241
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 12111
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 278
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 302
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 1513
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 34
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 3027
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 69
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 3395
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 78
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 15683
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 360
-	 } 
-	farmers = {
-		culture = khasi
-		religion =  protestant 
-		size = 136250
-	 } 
-	farmers = {
-		culture = khasi
-		religion = secularism
-		size = 3136
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 75694
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion = secularism
-		size = 1742
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 12390
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 36474
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 839
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 42
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 0
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 173
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 8719
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 200
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 217
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 1089
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 24
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 2179
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 49
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 2444
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 56
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 11291
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 259
+    }
+
+    farmers = {
+        culture = khasi
+        religion = protestant
+        size = 98100
+    }
+
+    farmers = {
+        culture = khasi
+        religion = secularism
+        size = 2257
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = protestant
+        size = 54499
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = secularism
+        size = 1254
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 8920
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 26261
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 604
+    }
 }
 #Dibrugarh - Assam (8017000/2004250 POPS)
 1260 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 391
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 9
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1566
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 36
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 78366
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1803
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1958
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 45
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 9795
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 225
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 19591
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 450
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 21974
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 505
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 140637
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 3237
-	 } 
-	farmers = {
-		culture = assamese
-		religion =  hindu 
-		size = 1097126
-	 } 
-	farmers = {
-		culture = assamese
-		religion = secularism
-		size = 25253
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 562140
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 281
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 6
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 1127
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 25
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 56423
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 1298
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1409
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 32
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 7052
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 162
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 14105
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 324
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 15821
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 363
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 101258
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 2330
+    }
+
+    farmers = {
+        culture = assamese
+        religion = hindu
+        size = 789930
+    }
+
+    farmers = {
+        culture = assamese
+        religion = secularism
+        size = 18182
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 404740
+    }
 }
 #Cuttack - Orissa (5848000/1462000 POPS)
 1261 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 285
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1142
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 57164
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1315
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1429
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7145
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 164
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14291
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 328
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16029
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 368
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1245871
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 28677
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 59173
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 205
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 822
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41158
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 946
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1028
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5144
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 118
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10289
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 236
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11540
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 264
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 897027
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 20647
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 42604
+    }
 }
 #Ajmer - Ajmer (4067000/1016750 POPS)
 1264 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 198
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 794
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 39754
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 915
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 993
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 22
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 4968
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 114
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 9938
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 228
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11147
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 256
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 906669
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 20869
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 142
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 571
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 28622
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 658
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 714
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3576
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 82
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7155
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 164
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8025
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 184
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 652801
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15025
+    }
 }
 #Bhopal - Madhya Pradesh (6072000/1518000 POPS)
 1272 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 296
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1186
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 27
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 59353
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1366
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1483
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 34
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7419
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 170
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14838
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 341
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16642
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 383
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 692404
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 692404
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 213
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 853
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 19
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 42734
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 983
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1067
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 24
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5341
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 122
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10683
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 245
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11982
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 275
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 498530
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 498530
+    }
 }
 #Jubulpore - Madhya Pradesh (6072000/1518000 POPS)
 1275 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 296
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1186
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 27
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 59353
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1366
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1483
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 34
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7419
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 170
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14838
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 341
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16642
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 383
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1115531
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 25677
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 243600
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 213
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 853
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 19
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 42734
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 983
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1067
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 24
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5341
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 122
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10683
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 245
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11982
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 275
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 803182
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 18487
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 175392
+    }
 }
 #Hoshangabad - Madhya Pradesh (6072000/1518000 POPS)
 1276 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 296
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1186
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 27
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 59353
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1366
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1483
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 34
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7419
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 170
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14838
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 341
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16642
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 383
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 692404
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 692404
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 213
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 853
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 19
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 42734
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 983
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1067
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 24
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5341
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 122
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10683
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 245
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11982
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 275
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 498530
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 498530
+    }
 }
 #Nagpur - Maharashtra (4460000/1115000 POPS)
 1277 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 217
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 871
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 20
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 43596
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1003
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1089
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 25
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5449
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 125
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10899
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 250
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 12224
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 281
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 994280
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 22886
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 156
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 627
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 14
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 31389
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 722
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 784
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3923
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 90
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7847
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 180
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8801
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 202
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 715881
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 16477
+    }
 }
 #Amarati - Maharashtra (4712000/1178000 POPS)
 1278 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 229
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 920
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 21
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 46059
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1060
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1151
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5757
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 132
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 11514
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 265
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 12915
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 297
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1050460
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 24179
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 164
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 662
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 33162
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 763
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 828
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4145
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 95
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8290
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 190
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9298
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 213
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 756331
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 17408
+    }
 }
 #Jagdalpur - Chhattisgarh (2671000/667750 POPS)
 1279 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 130
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 2
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 521
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 12
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 26109
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 600
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 651
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 15
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3262
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 75
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 6526
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 150
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 7320
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 168
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 595454
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 13706
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 93
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 375
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 18798
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 432
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 468
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2348
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 54
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 4698
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 108
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 5270
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 120
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 428726
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 9868
+    }
 }
 #Raipur - Chhattisgarh (2671000/667750 POPS)
 1280 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 130
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 2
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 521
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 12
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 26109
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 600
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 651
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 15
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3262
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 75
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 6526
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 150
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 7320
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 168
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 595454
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 13706
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 93
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 375
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 18798
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 432
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 468
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2348
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 54
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 4698
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 108
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 5270
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 120
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 428726
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 9868
+    }
 }
 #Bilaspur - Chhattisgarh (2671000/667750 POPS)
 1281 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 130
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 2
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 521
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 12
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 26109
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 600
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 651
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 15
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3262
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 75
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 6526
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 150
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 7320
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 168
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 595454
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 13706
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 93
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 375
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 18798
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 432
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 468
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2348
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 54
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 4698
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 108
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 5270
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 120
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 428726
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 9868
+    }
 }
 #Karachi - Karachi (7128000/1782000 POPS)
 1288 = {
-	soldiers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1425
-	 } 
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 71280
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1782
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 8910
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 17820
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 23117
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 712850
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 855360
-	 } 
-	farmers = {
-		culture = baluchi
-		religion =  sunni 
-		size = 33237
-	 } 
+    soldiers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1425
+    }
+
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 71280
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1782
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 8910
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 17820
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 23117
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 712850
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 855360
+    }
+
+    farmers = {
+        culture = baluchi
+        religion = sunni
+        size = 33237
+    }
 }
 #Sukkur - Sukkur (1625000/406250 POPS)
 1289 = {
-	aristocrats = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 16250
-	 } 
-	capitalists = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 2031
-	 } 
-	clergymen = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 4062
-	 } 
-	artisans = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 5270
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 73137
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 291950
-	 } 
+    aristocrats = {
+        culture = indian_shia
+        religion = shiite
+        size = 16250
+    }
+
+    capitalists = {
+        culture = indian_shia
+        religion = shiite
+        size = 2031
+    }
+
+    clergymen = {
+        culture = indian_shia
+        religion = shiite
+        size = 4062
+    }
+
+    artisans = {
+        culture = indian_shia
+        religion = shiite
+        size = 5270
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 73137
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 291950
+    }
 }
 #Umarkot - Umarkot (707000/176750 POPS)
 1290 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 34
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 139
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 1
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 6999
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 70
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 174
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 1
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 874
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 8
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 1749
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 17
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 2269
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 22
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 31504
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 318
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 127019
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 34
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 139
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 6999
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 70
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 174
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 874
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 1749
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 17
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 2269
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 22
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 31504
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 318
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 127019
+    }
 }
 #Ahmedabad - Gujarat (5946000/1486500 POPS)
 1291 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 290
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1162
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 58122
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1337
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1452
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 33
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7264
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 167
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14530
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 334
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16297
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 375
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1063322
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 24475
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 268274
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 208
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 836
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41847
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 962
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1045
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5230
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 120
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10461
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 240
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11733
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 270
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 765591
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 17622
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 193157
+    }
 }
 #Surat - Gujarat (3190000/797500 POPS)
 1296 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 155
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 3
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 623
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 14
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 31182
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 717
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 779
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 17
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3897
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 89
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 7795
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 179
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 8743
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 201
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 711156
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 16369
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 111
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 448
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 22451
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 516
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 560
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2805
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 64
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 5612
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 128
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 6294
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 144
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 512032
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 11785
+    }
 }
 #Bombay - Maharashtra (5019000/1254750 POPS)
 1297 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 244
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 980
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 22
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 49060
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1129
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1225
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 28
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6131
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 141
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 12264
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 282
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 13757
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 316
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1118322
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 25741
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 175
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 705
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 35323
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 812
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 882
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4414
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 101
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8830
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9905
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 227
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 805191
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 18533
+    }
 }
 #Nasik - Maharashtra (6597000/1649250 POPS)
 1298 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 321
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 7
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1289
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 29
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 64485
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1484
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1611
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 37
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 8060
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 185
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 16120
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 371
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 18082
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 416
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 727141
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 727141
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 50259
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 231
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 5
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 928
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 46429
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 1068
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1159
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 26
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5803
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 133
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 11606
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 267
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 13019
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 299
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 523541
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 523541
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 36186
+    }
 }
 #Poona - Maharashtra (5855000/1463750 POPS)
 1299 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 285
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1144
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 57232
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1317
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1430
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7153
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 164
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14307
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 329
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16048
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 369
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1261671
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 29041
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 44605
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 205
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 823
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41207
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 948
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1029
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5150
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 118
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10301
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 236
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11554
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 265
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 908403
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 20909
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 32115
+    }
 }
 #Bijapur - Maharashtra (2498000/624500 POPS)
 1300 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 121
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 2
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 487
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 11
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 24417
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 562
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 609
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 14
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3051
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 70
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 6104
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 140
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 6846
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 157
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 556888
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 12818
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 87
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 350
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 7
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 17580
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 404
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 438
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2196
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 50
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 4394
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 100
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 4929
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 113
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 400959
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 9228
+    }
 }
 #Kolhapur - Maharashtra (2010000/502500 POPS)
 1301 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 97
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 2
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 392
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 9
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 19647
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 452
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 490
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 11
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 2455
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 56
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 4911
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 113
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 5509
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 126
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 448094
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 10314
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 69
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 1
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 282
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 6
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 14145
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 325
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 352
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 7
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 1767
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 40
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 3535
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 81
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 3966
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 90
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 322627
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 7426
+    }
 }
 #Belgaum - Belgaum (5455000/1363750 POPS)
 1302 = {
-	officers = {
-		culture = kannada
-		religion =  hindu 
-		size = 265
-	 } 
-	officers = {
-		culture = kannada
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = kannada
-		religion =  hindu 
-		size = 1066
-	 } 
-	soldiers = {
-		culture = kannada
-		religion = secularism
-		size = 24
-	 } 
-	aristocrats = {
-		culture = kannada
-		religion =  hindu 
-		size = 53322
-	 } 
-	aristocrats = {
-		culture = kannada
-		religion = secularism
-		size = 1227
-	 } 
-	artisans = {
-		culture = kannada
-		religion =  hindu 
-		size = 1332
-	 } 
-	artisans = {
-		culture = kannada
-		religion = secularism
-		size = 30
-	 } 
-	capitalists = {
-		culture = kannada
-		religion =  hindu 
-		size = 6664
-	 } 
-	capitalists = {
-		culture = kannada
-		religion = secularism
-		size = 153
-	 } 
-	clergymen = {
-		culture = kannada
-		religion =  hindu 
-		size = 13330
-	 } 
-	clergymen = {
-		culture = kannada
-		religion = secularism
-		size = 306
-	 } 
-	artisans = {
-		culture = kannada
-		religion =  hindu 
-		size = 14951
-	 } 
-	artisans = {
-		culture = kannada
-		religion = secularism
-		size = 344
-	 } 
-	farmers = {
-		culture = kannada
-		religion =  hindu 
-		size = 1015510
-	 } 
-	farmers = {
-		culture = kannada
-		religion = secularism
-		size = 23374
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 205207
-	 } 
+    officers = {
+        culture = kannada
+        religion = hindu
+        size = 190
+    }
+
+    officers = {
+        culture = kannada
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = kannada
+        religion = hindu
+        size = 767
+    }
+
+    soldiers = {
+        culture = kannada
+        religion = secularism
+        size = 17
+    }
+
+    aristocrats = {
+        culture = kannada
+        religion = hindu
+        size = 38391
+    }
+
+    aristocrats = {
+        culture = kannada
+        religion = secularism
+        size = 883
+    }
+
+    artisans = {
+        culture = kannada
+        religion = hindu
+        size = 959
+    }
+
+    artisans = {
+        culture = kannada
+        religion = secularism
+        size = 21
+    }
+
+    capitalists = {
+        culture = kannada
+        religion = hindu
+        size = 4798
+    }
+
+    capitalists = {
+        culture = kannada
+        religion = secularism
+        size = 110
+    }
+
+    clergymen = {
+        culture = kannada
+        religion = hindu
+        size = 9597
+    }
+
+    clergymen = {
+        culture = kannada
+        religion = secularism
+        size = 220
+    }
+
+    artisans = {
+        culture = kannada
+        religion = hindu
+        size = 10764
+    }
+
+    artisans = {
+        culture = kannada
+        religion = secularism
+        size = 247
+    }
+
+    farmers = {
+        culture = kannada
+        religion = hindu
+        size = 731167
+    }
+
+    farmers = {
+        culture = kannada
+        religion = secularism
+        size = 16829
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 147749
+    }
 }
 #Madras - Madras (6205000/1551250 POPS)
 1304 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 303
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1213
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 27
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 60653
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1396
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1516
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 34
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7581
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 174
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 15162
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 349
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 17008
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 391
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 93685
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 2156
-	 } 
-	farmers = {
-		culture = tamil
-		religion =  hindu 
-		size = 652028
-	 } 
-	farmers = {
-		culture = tamil
-		religion = secularism
-		size = 15008
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 263712
-	 } 
-	farmers = {
-		culture = telegu
-		religion =  hindu 
-		size = 379805
-	 } 
-	farmers = {
-		culture = telegu
-		religion = secularism
-		size = 8742
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 218
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 873
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 19
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 43670
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 1005
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1091
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 24
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5458
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 125
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10916
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 251
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 12245
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 281
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 67453
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 1552
+    }
+
+    farmers = {
+        culture = tamil
+        religion = hindu
+        size = 469460
+    }
+
+    farmers = {
+        culture = tamil
+        religion = secularism
+        size = 10805
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 189872
+    }
+
+    farmers = {
+        culture = telegu
+        religion = hindu
+        size = 273459
+    }
+
+    farmers = {
+        culture = telegu
+        religion = secularism
+        size = 6294
+    }
 }
 #Vizagapatnam - Vizagapatnam (5163000/1290750 POPS)
 1305 = {
-	officers = {
-		culture = telegu
-		religion =  hindu 
-		size = 252
-	 } 
-	officers = {
-		culture = telegu
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = telegu
-		religion =  hindu 
-		size = 1008
-	 } 
-	soldiers = {
-		culture = telegu
-		religion = secularism
-		size = 23
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 50468
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion = secularism
-		size = 1161
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 1260
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 29
-	 } 
-	capitalists = {
-		culture = telegu
-		religion =  hindu 
-		size = 6307
-	 } 
-	capitalists = {
-		culture = telegu
-		religion = secularism
-		size = 145
-	 } 
-	clergymen = {
-		culture = telegu
-		religion =  hindu 
-		size = 12616
-	 } 
-	clergymen = {
-		culture = telegu
-		religion = secularism
-		size = 290
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 14152
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 325
-	 } 
-	farmers = {
-		culture = telegu
-		religion =  hindu 
-		size = 1151003
-	 } 
-	farmers = {
-		culture = telegu
-		religion = secularism
-		size = 26493
-	 } 
+    officers = {
+        culture = telegu
+        religion = hindu
+        size = 181
+    }
+
+    officers = {
+        culture = telegu
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = hindu
+        size = 725
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = secularism
+        size = 16
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = hindu
+        size = 36336
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = secularism
+        size = 835
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 907
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = hindu
+        size = 4541
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = secularism
+        size = 104
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = hindu
+        size = 9083
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = secularism
+        size = 208
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 10189
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 234
+    }
+
+    farmers = {
+        culture = telegu
+        religion = hindu
+        size = 828722
+    }
+
+    farmers = {
+        culture = telegu
+        religion = secularism
+        size = 19074
+    }
 }
 #Masulipatnam - Masulipatnam (5163000/1290750 POPS)
 1306 = {
-	officers = {
-		culture = telegu
-		religion =  hindu 
-		size = 252
-	 } 
-	officers = {
-		culture = telegu
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = telegu
-		religion =  hindu 
-		size = 1008
-	 } 
-	soldiers = {
-		culture = telegu
-		religion = secularism
-		size = 23
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 50468
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion = secularism
-		size = 1161
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 1260
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 29
-	 } 
-	capitalists = {
-		culture = telegu
-		religion =  hindu 
-		size = 6307
-	 } 
-	capitalists = {
-		culture = telegu
-		religion = secularism
-		size = 145
-	 } 
-	clergymen = {
-		culture = telegu
-		religion =  hindu 
-		size = 12616
-	 } 
-	clergymen = {
-		culture = telegu
-		religion = secularism
-		size = 290
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 14152
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 325
-	 } 
-	farmers = {
-		culture = telegu
-		religion =  hindu 
-		size = 1151003
-	 } 
-	farmers = {
-		culture = telegu
-		religion = secularism
-		size = 26493
-	 } 
+    officers = {
+        culture = telegu
+        religion = hindu
+        size = 181
+    }
+
+    officers = {
+        culture = telegu
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = hindu
+        size = 725
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = secularism
+        size = 16
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = hindu
+        size = 36336
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = secularism
+        size = 835
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 907
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = hindu
+        size = 4541
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = secularism
+        size = 104
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = hindu
+        size = 9083
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = secularism
+        size = 208
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 10189
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 234
+    }
+
+    farmers = {
+        culture = telegu
+        religion = hindu
+        size = 828722
+    }
+
+    farmers = {
+        culture = telegu
+        religion = secularism
+        size = 19074
+    }
 }
 #Nellore - Nellore (5163000/1290750 POPS)
 1307 = {
-	officers = {
-		culture = telegu
-		religion =  hindu 
-		size = 252
-	 } 
-	officers = {
-		culture = telegu
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = telegu
-		religion =  hindu 
-		size = 1008
-	 } 
-	soldiers = {
-		culture = telegu
-		religion = secularism
-		size = 23
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 50468
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion = secularism
-		size = 1161
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 1260
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 29
-	 } 
-	capitalists = {
-		culture = telegu
-		religion =  hindu 
-		size = 6307
-	 } 
-	capitalists = {
-		culture = telegu
-		religion = secularism
-		size = 145
-	 } 
-	clergymen = {
-		culture = telegu
-		religion =  hindu 
-		size = 12616
-	 } 
-	clergymen = {
-		culture = telegu
-		religion = secularism
-		size = 290
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 14152
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 325
-	 } 
-	farmers = {
-		culture = telegu
-		religion =  hindu 
-		size = 1112555
-	 } 
-	farmers = {
-		culture = telegu
-		religion = secularism
-		size = 25608
-	 } 
-	farmers = {
-		culture = tamil
-		religion =  hindu 
-		size = 38448
-	 } 
-	farmers = {
-		culture = tamil
-		religion = secularism
-		size = 884
-	 } 
+    officers = {
+        culture = telegu
+        religion = hindu
+        size = 181
+    }
+
+    officers = {
+        culture = telegu
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = hindu
+        size = 725
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = secularism
+        size = 16
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = hindu
+        size = 36336
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = secularism
+        size = 835
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 907
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = hindu
+        size = 4541
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = secularism
+        size = 104
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = hindu
+        size = 9083
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = secularism
+        size = 208
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 10189
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 234
+    }
+
+    farmers = {
+        culture = telegu
+        religion = hindu
+        size = 801039
+    }
+
+    farmers = {
+        culture = telegu
+        religion = secularism
+        size = 18437
+    }
+
+    farmers = {
+        culture = tamil
+        religion = hindu
+        size = 27682
+    }
+
+    farmers = {
+        culture = tamil
+        religion = secularism
+        size = 636
+    }
 }
 #Kurnool - Kurnool (5163000/1290750 POPS)
 1308 = {
-	officers = {
-		culture = telegu
-		religion =  hindu 
-		size = 252
-	 } 
-	officers = {
-		culture = telegu
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = telegu
-		religion =  hindu 
-		size = 1008
-	 } 
-	soldiers = {
-		culture = telegu
-		religion = secularism
-		size = 23
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion =  hindu 
-		size = 50468
-	 } 
-	aristocrats = {
-		culture = telegu
-		religion = secularism
-		size = 1161
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 1260
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 29
-	 } 
-	capitalists = {
-		culture = telegu
-		religion =  hindu 
-		size = 6307
-	 } 
-	capitalists = {
-		culture = telegu
-		religion = secularism
-		size = 145
-	 } 
-	clergymen = {
-		culture = telegu
-		religion =  hindu 
-		size = 12616
-	 } 
-	clergymen = {
-		culture = telegu
-		religion = secularism
-		size = 290
-	 } 
-	artisans = {
-		culture = telegu
-		religion =  hindu 
-		size = 14152
-	 } 
-	artisans = {
-		culture = telegu
-		religion = secularism
-		size = 325
-	 } 
-	farmers = {
-		culture = telegu
-		religion =  hindu 
-		size = 822362
-	 } 
-	farmers = {
-		culture = telegu
-		religion = secularism
-		size = 18929
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 180705
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 155500
-	 } 
+    officers = {
+        culture = telegu
+        religion = hindu
+        size = 181
+    }
+
+    officers = {
+        culture = telegu
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = hindu
+        size = 725
+    }
+
+    soldiers = {
+        culture = telegu
+        religion = secularism
+        size = 16
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = hindu
+        size = 36336
+    }
+
+    aristocrats = {
+        culture = telegu
+        religion = secularism
+        size = 835
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 907
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = hindu
+        size = 4541
+    }
+
+    capitalists = {
+        culture = telegu
+        religion = secularism
+        size = 104
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = hindu
+        size = 9083
+    }
+
+    clergymen = {
+        culture = telegu
+        religion = secularism
+        size = 208
+    }
+
+    artisans = {
+        culture = telegu
+        religion = hindu
+        size = 10189
+    }
+
+    artisans = {
+        culture = telegu
+        religion = secularism
+        size = 234
+    }
+
+    farmers = {
+        culture = telegu
+        religion = hindu
+        size = 592100
+    }
+
+    farmers = {
+        culture = telegu
+        religion = secularism
+        size = 13628
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 130107
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 111960
+    }
 }
 #Tanjore - Tanjore (6638000/1659500 POPS)
 1309 = {
-	officers = {
-		culture = tamil
-		religion =  hindu 
-		size = 323
-	 } 
-	officers = {
-		culture = tamil
-		religion = secularism
-		size = 7
-	 } 
-	soldiers = {
-		culture = tamil
-		religion =  hindu 
-		size = 1297
-	 } 
-	soldiers = {
-		culture = tamil
-		religion = secularism
-		size = 29
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion =  hindu 
-		size = 64886
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion = secularism
-		size = 1493
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 1621
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 37
-	 } 
-	capitalists = {
-		culture = tamil
-		religion =  hindu 
-		size = 8110
-	 } 
-	capitalists = {
-		culture = tamil
-		religion = secularism
-		size = 186
-	 } 
-	clergymen = {
-		culture = tamil
-		religion =  hindu 
-		size = 16221
-	 } 
-	clergymen = {
-		culture = tamil
-		religion = secularism
-		size = 373
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 18195
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 418
-	 } 
-	farmers = {
-		culture = tamil
-		religion =  hindu 
-		size = 1235737
-	 } 
-	farmers = {
-		culture = tamil
-		religion = secularism
-		size = 28444
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 249711
-	 } 
+    officers = {
+        culture = tamil
+        religion = hindu
+        size = 232
+    }
+
+    officers = {
+        culture = tamil
+        religion = secularism
+        size = 5
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = hindu
+        size = 933
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = secularism
+        size = 20
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = hindu
+        size = 46717
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = secularism
+        size = 1074
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 1167
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 26
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = hindu
+        size = 5839
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = secularism
+        size = 133
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = hindu
+        size = 11679
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = secularism
+        size = 268
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 13100
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 300
+    }
+
+    farmers = {
+        culture = tamil
+        religion = hindu
+        size = 889730
+    }
+
+    farmers = {
+        culture = tamil
+        religion = secularism
+        size = 20479
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 179791
+    }
 }
 #Madurai - Madurai (4088000/1022000 POPS)
 1310 = {
-	officers = {
-		culture = tamil
-		religion =  hindu 
-		size = 199
-	 } 
-	officers = {
-		culture = tamil
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = tamil
-		religion =  hindu 
-		size = 798
-	 } 
-	soldiers = {
-		culture = tamil
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion =  hindu 
-		size = 39960
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion = secularism
-		size = 919
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 999
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 22
-	 } 
-	capitalists = {
-		culture = tamil
-		religion =  hindu 
-		size = 4995
-	 } 
-	capitalists = {
-		culture = tamil
-		religion = secularism
-		size = 114
-	 } 
-	clergymen = {
-		culture = tamil
-		religion =  hindu 
-		size = 9990
-	 } 
-	clergymen = {
-		culture = tamil
-		religion = secularism
-		size = 229
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 11205
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 257
-	 } 
-	farmers = {
-		culture = tamil
-		religion =  hindu 
-		size = 890897
-	 } 
-	farmers = {
-		culture = tamil
-		religion = secularism
-		size = 20506
-	 } 
-	farmers = {
-		culture = christian_malayalam
-		religion =  orthodox 
-		size = 20453
-	 } 
-	farmers = {
-		culture = christian_malayalam
-		religion = secularism
-		size = 470
-	 } 
+    officers = {
+        culture = tamil
+        religion = hindu
+        size = 143
+    }
+
+    officers = {
+        culture = tamil
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = hindu
+        size = 574
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = hindu
+        size = 28771
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = secularism
+        size = 661
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 719
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 15
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = hindu
+        size = 3596
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = secularism
+        size = 82
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = hindu
+        size = 7192
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = secularism
+        size = 164
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 8067
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 185
+    }
+
+    farmers = {
+        culture = tamil
+        religion = hindu
+        size = 641445
+    }
+
+    farmers = {
+        culture = tamil
+        religion = secularism
+        size = 14764
+    }
+
+    farmers = {
+        culture = christian_malayalam
+        religion = orthodox
+        size = 14726
+    }
+
+    farmers = {
+        culture = christian_malayalam
+        religion = secularism
+        size = 338
+    }
 }
 #Coimbatore - Coimbatore (4182000/1045500 POPS)
 1311 = {
-	officers = {
-		culture = tamil
-		religion =  hindu 
-		size = 204
-	 } 
-	officers = {
-		culture = tamil
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = tamil
-		religion =  hindu 
-		size = 817
-	 } 
-	soldiers = {
-		culture = tamil
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion =  hindu 
-		size = 40879
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion = secularism
-		size = 940
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 1021
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = tamil
-		religion =  hindu 
-		size = 5109
-	 } 
-	capitalists = {
-		culture = tamil
-		religion = secularism
-		size = 117
-	 } 
-	clergymen = {
-		culture = tamil
-		religion =  hindu 
-		size = 10219
-	 } 
-	clergymen = {
-		culture = tamil
-		religion = secularism
-		size = 235
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 11462
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 263
-	 } 
-	farmers = {
-		culture = tamil
-		religion =  hindu 
-		size = 932307
-	 } 
-	farmers = {
-		culture = tamil
-		religion = secularism
-		size = 21459
-	 } 
+    officers = {
+        culture = tamil
+        religion = hindu
+        size = 146
+    }
+
+    officers = {
+        culture = tamil
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = hindu
+        size = 588
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = hindu
+        size = 29432
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = secularism
+        size = 676
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 735
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = hindu
+        size = 3678
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = hindu
+        size = 7357
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = secularism
+        size = 169
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 8252
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 189
+    }
+
+    farmers = {
+        culture = tamil
+        religion = hindu
+        size = 671261
+    }
+
+    farmers = {
+        culture = tamil
+        religion = secularism
+        size = 15450
+    }
 }
 #Mangalore - Mangalore (1258000/314500 POPS)
 1316 = {
-	officers = {
-		culture = kannada
-		religion =  hindu 
-		size = 60
-	 } 
-	officers = {
-		culture = kannada
-		religion = secularism
-		size = 1
-	 } 
-	soldiers = {
-		culture = kannada
-		religion =  hindu 
-		size = 245
-	 } 
-	soldiers = {
-		culture = kannada
-		religion = secularism
-		size = 5
-	 } 
-	aristocrats = {
-		culture = kannada
-		religion =  hindu 
-		size = 12296
-	 } 
-	aristocrats = {
-		culture = kannada
-		religion = secularism
-		size = 283
-	 } 
-	artisans = {
-		culture = kannada
-		religion =  hindu 
-		size = 306
-	 } 
-	artisans = {
-		culture = kannada
-		religion = secularism
-		size = 7
-	 } 
-	capitalists = {
-		culture = kannada
-		religion =  hindu 
-		size = 1536
-	 } 
-	capitalists = {
-		culture = kannada
-		religion = secularism
-		size = 35
-	 } 
-	clergymen = {
-		culture = kannada
-		religion =  hindu 
-		size = 3074
-	 } 
-	clergymen = {
-		culture = kannada
-		religion = secularism
-		size = 70
-	 } 
-	artisans = {
-		culture = kannada
-		religion =  hindu 
-		size = 3447
-	 } 
-	artisans = {
-		culture = kannada
-		religion = secularism
-		size = 79
-	 } 
-	farmers = {
-		culture = kannada
-		religion =  hindu 
-		size = 255713
-	 } 
-	farmers = {
-		culture = kannada
-		religion = secularism
-		size = 5885
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 25307
-	 } 
+    officers = {
+        culture = kannada
+        religion = hindu
+        size = 43
+    }
+
+    officers = {
+        culture = kannada
+        religion = secularism
+        size = 0
+    }
+
+    soldiers = {
+        culture = kannada
+        religion = hindu
+        size = 176
+    }
+
+    soldiers = {
+        culture = kannada
+        religion = secularism
+        size = 3
+    }
+
+    aristocrats = {
+        culture = kannada
+        religion = hindu
+        size = 8853
+    }
+
+    aristocrats = {
+        culture = kannada
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = kannada
+        religion = hindu
+        size = 220
+    }
+
+    artisans = {
+        culture = kannada
+        religion = secularism
+        size = 5
+    }
+
+    capitalists = {
+        culture = kannada
+        religion = hindu
+        size = 1105
+    }
+
+    capitalists = {
+        culture = kannada
+        religion = secularism
+        size = 25
+    }
+
+    clergymen = {
+        culture = kannada
+        religion = hindu
+        size = 2213
+    }
+
+    clergymen = {
+        culture = kannada
+        religion = secularism
+        size = 50
+    }
+
+    artisans = {
+        culture = kannada
+        religion = hindu
+        size = 2481
+    }
+
+    artisans = {
+        culture = kannada
+        religion = secularism
+        size = 56
+    }
+
+    farmers = {
+        culture = kannada
+        religion = hindu
+        size = 184113
+    }
+
+    farmers = {
+        culture = kannada
+        religion = secularism
+        size = 4237
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 18221
+    }
 }
 #Calicut - Calicut (4953000/1238250 POPS)
 1317 = {
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 49530
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1238
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 6191
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 12382
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 13889
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 373685
-	 } 
-	farmers = {
-		culture = malayalam
-		religion =  hindu 
-		size = 738910
-	 } 
-	farmers = {
-		culture = malayalam
-		religion = secularism
-		size = 17008
-	 } 
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 35661
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 891
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 4457
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 8915
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10000
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 269053
+    }
+
+    farmers = {
+        culture = malayalam
+        religion = hindu
+        size = 532015
+    }
+
+    farmers = {
+        culture = malayalam
+        religion = secularism
+        size = 12245
+    }
 }
 #Andaman Islands - Andaman Islands (158000/39500 POPS)
 1320 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 30
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1544
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 35
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 38
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 192
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 386
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 8
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 433
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 9
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 35224
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 810
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 21
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 1111
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 25
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 27
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 138
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 277
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 5
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 311
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 6
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 25361
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 583
+    }
 }
 #Tawang - Tawang (578000/144500 POPS)
 1593 = {
-	officers = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 27
-	 } 
-	soldiers = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 112
-	 } 
-	soldiers = {
-		culture = tibetan
-		religion = secularism
-		size = 2
-	 } 
-	aristocrats = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 5649
-	 } 
-	aristocrats = {
-		culture = tibetan
-		religion = secularism
-		size = 130
-	 } 
-	artisans = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 140
-	 } 
-	artisans = {
-		culture = tibetan
-		religion = secularism
-		size = 3
-	 } 
-	capitalists = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 705
-	 } 
-	capitalists = {
-		culture = tibetan
-		religion = secularism
-		size = 16
-	 } 
-	clergymen = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 1412
-	 } 
-	clergymen = {
-		culture = tibetan
-		religion = secularism
-		size = 32
-	 } 
-	artisans = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 1583
-	 } 
-	artisans = {
-		culture = tibetan
-		religion = secularism
-		size = 36
-	 } 
-	farmers = {
-		culture = tibetan
-		religion =  buddhist 
-		size = 8730
-	 } 
-	farmers = {
-		culture = tibetan
-		religion = secularism
-		size = 200
-	 } 
-	farmers = {
-		culture = assamese
-		religion =  hindu 
-		size = 48024
-	 } 
-	farmers = {
-		culture = assamese
-		religion = secularism
-		size = 1105
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 46612
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion = secularism
-		size = 1072
-	 } 
-	farmers = {
-		culture = naga
-		religion =  protestant 
-		size = 25490
-	 } 
-	farmers = {
-		culture = naga
-		religion = secularism
-		size = 586
-	 } 
+    officers = {
+        culture = tibetan
+        religion = buddhist
+        size = 19
+    }
+
+    soldiers = {
+        culture = tibetan
+        religion = buddhist
+        size = 80
+    }
+
+    soldiers = {
+        culture = tibetan
+        religion = secularism
+        size = 1
+    }
+
+    aristocrats = {
+        culture = tibetan
+        religion = buddhist
+        size = 4067
+    }
+
+    aristocrats = {
+        culture = tibetan
+        religion = secularism
+        size = 93
+    }
+
+    artisans = {
+        culture = tibetan
+        religion = buddhist
+        size = 100
+    }
+
+    artisans = {
+        culture = tibetan
+        religion = secularism
+        size = 2
+    }
+
+    capitalists = {
+        culture = tibetan
+        religion = buddhist
+        size = 507
+    }
+
+    capitalists = {
+        culture = tibetan
+        religion = secularism
+        size = 11
+    }
+
+    clergymen = {
+        culture = tibetan
+        religion = buddhist
+        size = 1016
+    }
+
+    clergymen = {
+        culture = tibetan
+        religion = secularism
+        size = 23
+    }
+
+    artisans = {
+        culture = tibetan
+        religion = buddhist
+        size = 1139
+    }
+
+    artisans = {
+        culture = tibetan
+        religion = secularism
+        size = 25
+    }
+
+    farmers = {
+        culture = tibetan
+        religion = buddhist
+        size = 6285
+    }
+
+    farmers = {
+        culture = tibetan
+        religion = secularism
+        size = 144
+    }
+
+    farmers = {
+        culture = assamese
+        religion = hindu
+        size = 34577
+    }
+
+    farmers = {
+        culture = assamese
+        religion = secularism
+        size = 795
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = protestant
+        size = 33560
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = secularism
+        size = 771
+    }
+
+    farmers = {
+        culture = naga
+        religion = protestant
+        size = 18352
+    }
+
+    farmers = {
+        culture = naga
+        religion = secularism
+        size = 421
+    }
 }
 #Agartala - Mizoram (456000/114000 POPS)
 2566 = {
-	officers = {
-		culture = tripuri
-		religion =  hindu 
-		size = 21
-	 } 
-	soldiers = {
-		culture = tripuri
-		religion =  hindu 
-		size = 88
-	 } 
-	soldiers = {
-		culture = tripuri
-		religion = secularism
-		size = 2
-	 } 
-	aristocrats = {
-		culture = tripuri
-		religion =  hindu 
-		size = 2118
-	 } 
-	aristocrats = {
-		culture = tripuri
-		religion = secularism
-		size = 48
-	 } 
-	aristocrats = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 2339
-	 } 
-	aristocrats = {
-		culture = asian_minor
-		religion = secularism
-		size = 53
-	 } 
-	artisans = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 111
-	 } 
-	artisans = {
-		culture = asian_minor
-		religion = secularism
-		size = 2
-	 } 
-	capitalists = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 557
-	 } 
-	capitalists = {
-		culture = asian_minor
-		religion = secularism
-		size = 12
-	 } 
-	clergymen = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 1114
-	 } 
-	clergymen = {
-		culture = asian_minor
-		religion = secularism
-		size = 25
-	 } 
-	artisans = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 1249
-	 } 
-	artisans = {
-		culture = asian_minor
-		religion = secularism
-		size = 28
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 16915
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion = secularism
-		size = 389
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 3343
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 76
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 1140
-	 } 
-	farmers = {
-		culture = mizoram
-		religion =  protestant 
-		size = 80285
-	 } 
-	farmers = {
-		culture = mizoram
-		religion = secularism
-		size = 1847
-	 } 
+    officers = {
+        culture = tripuri
+        religion = hindu
+        size = 15
+    }
+
+    soldiers = {
+        culture = tripuri
+        religion = hindu
+        size = 63
+    }
+
+    soldiers = {
+        culture = tripuri
+        religion = secularism
+        size = 1
+    }
+
+    aristocrats = {
+        culture = tripuri
+        religion = hindu
+        size = 1524
+    }
+
+    aristocrats = {
+        culture = tripuri
+        religion = secularism
+        size = 34
+    }
+
+    aristocrats = {
+        culture = asian_minor
+        religion = protestant
+        size = 1684
+    }
+
+    aristocrats = {
+        culture = asian_minor
+        religion = secularism
+        size = 38
+    }
+
+    artisans = {
+        culture = asian_minor
+        religion = protestant
+        size = 79
+    }
+
+    artisans = {
+        culture = asian_minor
+        religion = secularism
+        size = 1
+    }
+
+    capitalists = {
+        culture = asian_minor
+        religion = protestant
+        size = 401
+    }
+
+    capitalists = {
+        culture = asian_minor
+        religion = secularism
+        size = 8
+    }
+
+    clergymen = {
+        culture = asian_minor
+        religion = protestant
+        size = 802
+    }
+
+    clergymen = {
+        culture = asian_minor
+        religion = secularism
+        size = 18
+    }
+
+    artisans = {
+        culture = asian_minor
+        religion = protestant
+        size = 899
+    }
+
+    artisans = {
+        culture = asian_minor
+        religion = secularism
+        size = 20
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = protestant
+        size = 12178
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = secularism
+        size = 280
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 2406
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 54
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 820
+    }
+
+    farmers = {
+        culture = mizoram
+        religion = protestant
+        size = 57805
+    }
+
+    farmers = {
+        culture = mizoram
+        religion = secularism
+        size = 1329
+    }
 }
 #Srednekolymsk - Purnia (5019000/1254750 POPS)
 2621 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 244
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 980
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 22
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 49060
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1129
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1225
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 28
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6131
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 141
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 12264
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 282
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 13757
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 316
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 934344
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 21506
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 188806
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 175
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 705
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 35323
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 812
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 882
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4414
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 101
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8830
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9905
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 227
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 672727
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15484
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 135940
+    }
 }
 #Markovo - Parganas (4182000/1045500 POPS)
 2622 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 204
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 817
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 40879
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 940
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1021
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 5109
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 117
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 10219
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 235
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 11462
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 263
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 798966
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 18390
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 136410
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 146
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 588
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 29432
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 676
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 735
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 3678
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 7357
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 169
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 8252
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 189
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 575255
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 13240
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 98215
+    }
 }
 #Novo Mariinsk - Narayanganj (5333000/1333250 POPS)
 2637 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 258
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 7
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1034
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 31
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 51730
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1599
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1293
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 39
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 6466
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 199
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 12932
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 399
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 13161
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 407
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 42450
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1312
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 1183222
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 258
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 7
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1034
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 31
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 51730
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1599
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1293
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 39
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 6466
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 199
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 12932
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 399
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 13161
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 407
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 42450
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1312
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 1183222
+    }
 }
 #Ust Nera - Muzaffarpur (5019000/1254750 POPS)
 2642 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 244
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 980
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 22
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 49060
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1129
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1225
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 28
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6131
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 141
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 12264
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 282
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 13757
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 316
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 934344
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 21506
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 150570
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 38236
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 175
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 705
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 35323
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 812
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 882
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4414
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 101
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8830
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9905
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 227
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 672727
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15484
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 108410
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 27529
+    }
 }
 #Olyekminsk - Kanpur (5379000/1344750 POPS)
 2644 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 261
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1050
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 24
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 52579
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1210
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1313
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 30
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6571
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 151
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 13144
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 302
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 14743
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 339
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 883058
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 20326
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 323375
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 187
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 756
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 17
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 37856
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 871
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 945
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 21
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4731
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 108
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 9463
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 217
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 10614
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 244
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 635801
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 14634
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 232830
+    }
 }
 #Nyurba - Moradabad (5826000/1456500 POPS)
 2650 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 284
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1138
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 56949
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1310
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1423
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7118
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 163
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14237
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 327
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 15969
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 367
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 956438
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 22015
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 350251
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 204
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 819
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41003
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 943
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1024
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5124
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 117
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10250
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 235
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11497
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 264
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 688635
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15850
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 252180
+    }
 }
 #Udanchniy - Faridabad (5301000/1325250 POPS)
 2651 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 259
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1036
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 51817
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1192
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1295
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 29
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6476
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 149
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 12953
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 298
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 14529
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 334
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1051612
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 24205
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 79515
-	 } 
-	farmers = {
-		culture = sikh
-		religion =  sikh 
-		size = 52431
-	 } 
-	farmers = {
-		culture = sikh
-		religion = secularism
-		size = 1206
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 186
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 745
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 37308
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 858
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 932
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4662
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 107
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 9326
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 214
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 10460
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 240
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 757160
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 17427
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 57250
+    }
+
+    farmers = {
+        culture = sikh
+        religion = sikh
+        size = 37750
+    }
+
+    farmers = {
+        culture = sikh
+        religion = secularism
+        size = 868
+    }
 }
 #Khatanga - Munger (2844000/711000 POPS)
 2654 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 138
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 3
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 555
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 12
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 27800
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 639
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 695
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 15
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 3475
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 79
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 6950
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 159
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 7795
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 179
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 466892
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 10746
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 170976
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 99
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 399
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 20016
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 460
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 500
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2502
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 56
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 5004
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 114
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 5612
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 128
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 336162
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 7737
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 123102
+    }
 }
 #Tura - Thane (3346000/836500 POPS)
 2655 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 163
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 3
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 653
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 15
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 32707
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 752
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 817
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 18
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 4087
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 94
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 8176
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 188
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 9170
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 211
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 745548
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 17160
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 117
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 470
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 23549
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 541
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 588
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 2942
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 67
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 5886
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 135
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 6602
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 151
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 536794
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 12355
+    }
 }
 #Svetlogorsk - Khulna (2370000/592500 POPS)
 2657 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 114
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 3
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 459
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 14
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 22989
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 711
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 574
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 17
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 2873
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 88
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 5747
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 177
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 5849
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 180
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 105074
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 3249
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 436950
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 114
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 459
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 14
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 22989
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 711
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 574
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 17
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 2873
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 88
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 5747
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 177
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 5849
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 180
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 105074
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 3249
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 436950
+    }
 }
 #Gheta - Comilla (2963000/740750 POPS)
 2658 = {
-	aristocrats = {
-		culture = bengali
-		religion =  sunni 
-		size = 29630
-	 } 
-	capitalists = {
-		culture = bengali
-		religion =  sunni 
-		size = 3703
-	 } 
-	clergymen = {
-		culture = bengali
-		religion =  sunni 
-		size = 7407
-	 } 
-	artisans = {
-		culture = bengali
-		religion =  sunni 
-		size = 7539
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 676176
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 5366
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 165
-	 } 
+    aristocrats = {
+        culture = bengali
+        religion = sunni
+        size = 29630
+    }
+
+    capitalists = {
+        culture = bengali
+        religion = sunni
+        size = 3703
+    }
+
+    clergymen = {
+        culture = bengali
+        religion = sunni
+        size = 7407
+    }
+
+    artisans = {
+        culture = bengali
+        religion = sunni
+        size = 7539
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 676176
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 5366
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 165
+    }
 }
 #Bereyezovka - Midnapore (5019000/1254750 POPS)
 2660 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 244
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 980
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 22
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 49060
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1129
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1225
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 28
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 6131
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 141
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 12264
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 282
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 13757
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 316
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 958874
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 22071
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 163711
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 175
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 705
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 35323
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 812
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 882
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 4414
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 101
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 8830
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 9905
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 227
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 690389
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 15891
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 117871
+    }
 }
 #Nizhnekolymsk - Baharampur (5019000/1254750 POPS)
 2661 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 244
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 980
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 22
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 49060
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1129
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1225
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 28
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 6131
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 141
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 12264
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 282
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 13757
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 316
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 713571
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 16424
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 414661
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 175
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 705
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 35323
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 812
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 882
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 4414
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 101
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 8830
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 9905
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 227
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 513771
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 11825
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 298555
+    }
 }
 #Cherskiy - Katihar (5019000/1254750 POPS)
 2662 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 244
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 980
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 22
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 49060
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1129
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1225
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 28
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6131
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 141
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 12264
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 282
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 13757
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 316
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 934344
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 21506
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 188806
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 175
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 705
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 35323
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 812
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 882
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4414
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 101
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8830
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9905
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 227
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 672727
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15484
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 135940
+    }
 }
 #Oyotuni - Jamshedpur (5855000/1463750 POPS)
 2664 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 285
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 6
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 1144
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 26
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 57232
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1317
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1430
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 32
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 7153
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 164
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 14307
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 329
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 16048
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 369
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1104282
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 25418
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 205617
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 205
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 4
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 823
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 41207
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 948
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 1029
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 23
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 5150
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 118
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 10301
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 236
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 11554
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 265
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 795083
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 18300
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 148044
+    }
 }
 #Pevek - Mymensingh (5333000/1333250 POPS)
 2666 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 258
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 7
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1034
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 31
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 51730
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1599
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 1293
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 39
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 6466
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 199
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 12932
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 399
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 13161
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 407
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 42450
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1312
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 1183222
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 258
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 7
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1034
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 31
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 51730
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1599
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 1293
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 39
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 6466
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 199
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 12932
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 399
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 13161
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 407
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 42450
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1312
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 1183222
+    }
 }
 #Verkhoyansk - Darbhanga (5019000/1254750 POPS)
 2668 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 244
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 980
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 22
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 49060
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1129
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1225
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 28
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6131
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 141
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 12264
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 282
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 13757
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 316
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 934344
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 21506
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 150570
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 38236
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 175
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 705
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 35323
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 812
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 882
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4414
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 101
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8830
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9905
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 227
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 672727
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15484
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 108410
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 27529
+    }
 }
 #Amga - Raebareli (4346000/1086500 POPS)
 2669 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 212
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 849
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 19
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 42482
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 977
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1061
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 24
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5309
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 122
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10620
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 244
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11911
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 274
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 734713
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 16911
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 152110
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 87434
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 152
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 611
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 13
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 30587
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 703
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 763
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 17
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3822
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 87
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7646
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 175
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8575
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 197
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 528993
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 12175
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 109519
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 62952
+    }
 }
 #Tiksi - Azamgarh (4182000/1045500 POPS)
 2670 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 204
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 817
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 40879
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 940
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1021
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5109
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 117
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10219
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 235
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11462
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 263
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 788746
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 18155
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 62730
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 84135
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 146
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 588
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 29432
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 676
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 735
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3678
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7357
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 169
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8252
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 189
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 567897
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 13071
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 45165
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 60577
+    }
 }
 #Zhilinda - Gonda (4182000/1045500 POPS)
 2671 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 204
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 817
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 40879
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 940
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1021
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5109
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 117
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10219
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 235
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11462
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 263
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 706988
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 16273
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 146370
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 84135
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 146
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 588
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 29432
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 676
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 735
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3678
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7357
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 169
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8252
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 189
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 509031
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 11716
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 105386
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 60577
+    }
 }
 #Olenyok - Faisalabad (4072000/1018000 POPS)
 2673 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 200
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 2
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 805
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 8
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 19149
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 193
-	 } 
-	aristocrats = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 21377
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 1018
-	 } 
-	capitalists = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 5090
-	 } 
-	clergymen = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 10180
-	 } 
-	artisans = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 13206
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 783889
-	 } 
-	farmers = {
-		culture = indian_shia
-		religion =  shiite 
-		size = 130967
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 200
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 805
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 19149
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 193
+    }
+
+    aristocrats = {
+        culture = indian_muslim
+        religion = sunni
+        size = 21377
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 1018
+    }
+
+    capitalists = {
+        culture = indian_muslim
+        religion = sunni
+        size = 5090
+    }
+
+    clergymen = {
+        culture = indian_muslim
+        religion = sunni
+        size = 10180
+    }
+
+    artisans = {
+        culture = indian_muslim
+        religion = sunni
+        size = 13206
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 783889
+    }
+
+    farmers = {
+        culture = indian_shia
+        religion = shiite
+        size = 130967
+    }
 }
 #Essey - Salem (3189000/797250 POPS)
 2674 = {
-	officers = {
-		culture = tamil
-		religion =  hindu 
-		size = 155
-	 } 
-	officers = {
-		culture = tamil
-		religion = secularism
-		size = 3
-	 } 
-	soldiers = {
-		culture = tamil
-		religion =  hindu 
-		size = 622
-	 } 
-	soldiers = {
-		culture = tamil
-		religion = secularism
-		size = 14
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion =  hindu 
-		size = 31172
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion = secularism
-		size = 717
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 779
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 17
-	 } 
-	capitalists = {
-		culture = tamil
-		religion =  hindu 
-		size = 3896
-	 } 
-	capitalists = {
-		culture = tamil
-		religion = secularism
-		size = 89
-	 } 
-	clergymen = {
-		culture = tamil
-		religion =  hindu 
-		size = 7792
-	 } 
-	clergymen = {
-		culture = tamil
-		religion = secularism
-		size = 179
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 8740
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 201
-	 } 
-	farmers = {
-		culture = tamil
-		religion =  hindu 
-		size = 710933
-	 } 
-	farmers = {
-		culture = tamil
-		religion = secularism
-		size = 16364
-	 } 
+    officers = {
+        culture = tamil
+        religion = hindu
+        size = 111
+    }
+
+    officers = {
+        culture = tamil
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = hindu
+        size = 447
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = secularism
+        size = 10
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = hindu
+        size = 22443
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = secularism
+        size = 516
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 560
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 12
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = hindu
+        size = 2805
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = secularism
+        size = 64
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = hindu
+        size = 5610
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = secularism
+        size = 128
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 6292
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 144
+    }
+
+    farmers = {
+        culture = tamil
+        religion = hindu
+        size = 511871
+    }
+
+    farmers = {
+        culture = tamil
+        religion = secularism
+        size = 11782
+    }
 }
 #Yekonda - Tirunelveli (3346000/836500 POPS)
 2675 = {
-	officers = {
-		culture = tamil
-		religion =  hindu 
-		size = 163
-	 } 
-	officers = {
-		culture = tamil
-		religion = secularism
-		size = 3
-	 } 
-	soldiers = {
-		culture = tamil
-		religion =  hindu 
-		size = 653
-	 } 
-	soldiers = {
-		culture = tamil
-		religion = secularism
-		size = 15
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion =  hindu 
-		size = 32707
-	 } 
-	aristocrats = {
-		culture = tamil
-		religion = secularism
-		size = 752
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 817
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 18
-	 } 
-	capitalists = {
-		culture = tamil
-		religion =  hindu 
-		size = 4087
-	 } 
-	capitalists = {
-		culture = tamil
-		religion = secularism
-		size = 94
-	 } 
-	clergymen = {
-		culture = tamil
-		religion =  hindu 
-		size = 8176
-	 } 
-	clergymen = {
-		culture = tamil
-		religion = secularism
-		size = 188
-	 } 
-	artisans = {
-		culture = tamil
-		religion =  hindu 
-		size = 9170
-	 } 
-	artisans = {
-		culture = tamil
-		religion = secularism
-		size = 211
-	 } 
-	farmers = {
-		culture = tamil
-		religion =  hindu 
-		size = 729194
-	 } 
-	farmers = {
-		culture = tamil
-		religion = secularism
-		size = 16784
-	 } 
-	farmers = {
-		culture = christian_malayalam
-		religion =  orthodox 
-		size = 16739
-	 } 
-	farmers = {
-		culture = christian_malayalam
-		religion = secularism
-		size = 385
-	 } 
+    officers = {
+        culture = tamil
+        religion = hindu
+        size = 117
+    }
+
+    officers = {
+        culture = tamil
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = hindu
+        size = 470
+    }
+
+    soldiers = {
+        culture = tamil
+        religion = secularism
+        size = 10
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = hindu
+        size = 23549
+    }
+
+    aristocrats = {
+        culture = tamil
+        religion = secularism
+        size = 541
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 588
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 12
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = hindu
+        size = 2942
+    }
+
+    capitalists = {
+        culture = tamil
+        religion = secularism
+        size = 67
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = hindu
+        size = 5886
+    }
+
+    clergymen = {
+        culture = tamil
+        religion = secularism
+        size = 135
+    }
+
+    artisans = {
+        culture = tamil
+        religion = hindu
+        size = 6602
+    }
+
+    artisans = {
+        culture = tamil
+        religion = secularism
+        size = 151
+    }
+
+    farmers = {
+        culture = tamil
+        religion = hindu
+        size = 525019
+    }
+
+    farmers = {
+        culture = tamil
+        religion = secularism
+        size = 12084
+    }
+
+    farmers = {
+        culture = christian_malayalam
+        religion = orthodox
+        size = 12052
+    }
+
+    farmers = {
+        culture = christian_malayalam
+        religion = secularism
+        size = 277
+    }
 }
 #Dudinka - Chittagong Hill Tracts (421000/105250 POPS)
 2680 = {
-	aristocrats = {
-		culture = bengali
-		religion =  sunni 
-		size = 4210
-	 } 
-	clergymen = {
-		culture = bengali
-		religion =  sunni 
-		size = 1052
-	 } 
-	artisans = {
-		culture = bengali
-		religion =  sunni 
-		size = 1071
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 36083
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 56150
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion = secularism
-		size = 1736
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 2041
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 63
-	 } 
+    aristocrats = {
+        culture = bengali
+        religion = sunni
+        size = 4210
+    }
+
+    clergymen = {
+        culture = bengali
+        religion = sunni
+        size = 1052
+    }
+
+    artisans = {
+        culture = bengali
+        religion = sunni
+        size = 1071
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 36083
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = protestant
+        size = 56150
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = secularism
+        size = 1736
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 2041
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 63
+    }
 }
 #Kostino - Rangpur (3555000/888750 POPS)
 2692 = {
-	officers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 171
-	 } 
-	officers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 689
-	 } 
-	soldiers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 21
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 34483
-	 } 
-	aristocrats = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 1066
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 861
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 26
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 4309
-	 } 
-	capitalists = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 133
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 8620
-	 } 
-	clergymen = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 266
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 8773
-	 } 
-	artisans = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 271
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 114507
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 3541
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 699864
-	 } 
+    officers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 171
+    }
+
+    officers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 5
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 689
+    }
+
+    soldiers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 21
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 34483
+    }
+
+    aristocrats = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 1066
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 861
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 26
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 4309
+    }
+
+    capitalists = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 133
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 8620
+    }
+
+    clergymen = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 266
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 8773
+    }
+
+    artisans = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 271
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 114507
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 3541
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 699864
+    }
 }
 #Uchami - Guwahati (5019000/1254750 POPS)
 2693 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 244
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 5
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 980
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 22
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 49060
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1129
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1225
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 28
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6131
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 141
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 12264
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 282
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 13757
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 316
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 88047
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 2026
-	 } 
-	farmers = {
-		culture = assamese
-		religion =  hindu 
-		size = 429280
-	 } 
-	farmers = {
-		culture = assamese
-		religion = secularism
-		size = 9881
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 439162
-	 } 
-	farmers = {
-		culture = nepali
-		religion =  hindu 
-		size = 36795
-	 } 
-	farmers = {
-		culture = nepali
-		religion = secularism
-		size = 846
-	 } 
-	farmers = {
-		culture = bodo
-		religion =  hindu 
-		size = 135498
-	 } 
-	farmers = {
-		culture = bodo
-		religion = secularism
-		size = 3118
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 175
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 3
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 705
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 15
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 35323
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 812
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 882
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 20
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4414
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 101
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8830
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 203
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9905
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 227
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 63393
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 1458
+    }
+
+    farmers = {
+        culture = assamese
+        religion = hindu
+        size = 309081
+    }
+
+    farmers = {
+        culture = assamese
+        religion = secularism
+        size = 7114
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 316196
+    }
+
+    farmers = {
+        culture = nepali
+        religion = hindu
+        size = 26492
+    }
+
+    farmers = {
+        culture = nepali
+        religion = secularism
+        size = 609
+    }
+
+    farmers = {
+        culture = bodo
+        religion = hindu
+        size = 97558
+    }
+
+    farmers = {
+        culture = bodo
+        religion = secularism
+        size = 2244
+    }
 }
 #Vanavara - Vadodara (4182000/1045500 POPS)
 2694 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 204
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 4
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 817
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 18
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 40879
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 940
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 1021
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5109
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 117
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10219
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 235
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11462
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 263
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 932307
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 21459
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 146
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 588
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 29432
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 676
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 735
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3678
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7357
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 169
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8252
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 189
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 671261
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15450
+    }
 }
 #Tirap - Tawang (108000/27000 POPS)
 3278 = {
-	officers = {
-		culture = assamese
-		religion =  hindu 
-		size = 4
-	 } 
-	soldiers = {
-		culture = assamese
-		religion =  hindu 
-		size = 20
-	 } 
-	aristocrats = {
-		culture = assamese
-		religion =  hindu 
-		size = 1055
-	 } 
-	aristocrats = {
-		culture = assamese
-		religion = secularism
-		size = 24
-	 } 
-	artisans = {
-		culture = assamese
-		religion =  hindu 
-		size = 26
-	 } 
-	capitalists = {
-		culture = assamese
-		religion =  hindu 
-		size = 131
-	 } 
-	capitalists = {
-		culture = assamese
-		religion = secularism
-		size = 3
-	 } 
-	clergymen = {
-		culture = assamese
-		religion =  hindu 
-		size = 263
-	 } 
-	clergymen = {
-		culture = assamese
-		religion = secularism
-		size = 6
-	 } 
-	artisans = {
-		culture = assamese
-		religion =  hindu 
-		size = 295
-	 } 
-	artisans = {
-		culture = assamese
-		religion = secularism
-		size = 6
-	 } 
-	farmers = {
-		culture = assamese
-		religion =  hindu 
-		size = 4535
-	 } 
-	farmers = {
-		culture = assamese
-		religion = secularism
-		size = 104
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 9501
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion = secularism
-		size = 218
-	 } 
-	farmers = {
-		culture = naga
-		religion =  protestant 
-		size = 10039
-	 } 
-	farmers = {
-		culture = naga
-		religion = secularism
-		size = 231
-	 } 
+    officers = {
+        culture = assamese
+        religion = hindu
+        size = 2
+    }
+
+    soldiers = {
+        culture = assamese
+        religion = hindu
+        size = 14
+    }
+
+    aristocrats = {
+        culture = assamese
+        religion = hindu
+        size = 759
+    }
+
+    aristocrats = {
+        culture = assamese
+        religion = secularism
+        size = 17
+    }
+
+    artisans = {
+        culture = assamese
+        religion = hindu
+        size = 18
+    }
+
+    capitalists = {
+        culture = assamese
+        religion = hindu
+        size = 94
+    }
+
+    capitalists = {
+        culture = assamese
+        religion = secularism
+        size = 2
+    }
+
+    clergymen = {
+        culture = assamese
+        religion = hindu
+        size = 189
+    }
+
+    clergymen = {
+        culture = assamese
+        religion = secularism
+        size = 4
+    }
+
+    artisans = {
+        culture = assamese
+        religion = hindu
+        size = 212
+    }
+
+    artisans = {
+        culture = assamese
+        religion = secularism
+        size = 4
+    }
+
+    farmers = {
+        culture = assamese
+        religion = hindu
+        size = 3265
+    }
+
+    farmers = {
+        culture = assamese
+        religion = secularism
+        size = 74
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = protestant
+        size = 6840
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = secularism
+        size = 156
+    }
+
+    farmers = {
+        culture = naga
+        religion = protestant
+        size = 7228
+    }
+
+    farmers = {
+        culture = naga
+        religion = secularism
+        size = 166
+    }
 }
 #Nagaland - Nagaland (828000/207000 POPS)
 3279 = {
-	officers = {
-		culture = assamese
-		religion =  hindu 
-		size = 40
-	 } 
-	soldiers = {
-		culture = assamese
-		religion =  hindu 
-		size = 161
-	 } 
-	soldiers = {
-		culture = assamese
-		religion = secularism
-		size = 3
-	 } 
-	aristocrats = {
-		culture = assamese
-		religion =  hindu 
-		size = 8093
-	 } 
-	aristocrats = {
-		culture = assamese
-		religion = secularism
-		size = 186
-	 } 
-	artisans = {
-		culture = assamese
-		religion =  hindu 
-		size = 202
-	 } 
-	artisans = {
-		culture = assamese
-		religion = secularism
-		size = 4
-	 } 
-	capitalists = {
-		culture = assamese
-		religion =  hindu 
-		size = 1011
-	 } 
-	capitalists = {
-		culture = assamese
-		religion = secularism
-		size = 23
-	 } 
-	clergymen = {
-		culture = assamese
-		religion =  hindu 
-		size = 2023
-	 } 
-	clergymen = {
-		culture = assamese
-		religion = secularism
-		size = 46
-	 } 
-	artisans = {
-		culture = assamese
-		religion =  hindu 
-		size = 2268
-	 } 
-	artisans = {
-		culture = assamese
-		religion = secularism
-		size = 52
-	 } 
-	farmers = {
-		culture = assamese
-		religion =  hindu 
-		size = 2386
-	 } 
-	farmers = {
-		culture = assamese
-		religion = secularism
-		size = 54
-	 } 
-	farmers = {
-		culture = naga
-		religion =  protestant 
-		size = 182108
-	 } 
-	farmers = {
-		culture = naga
-		religion = secularism
-		size = 4191
-	 } 
+    officers = {
+        culture = assamese
+        religion = hindu
+        size = 28
+    }
+
+    soldiers = {
+        culture = assamese
+        religion = hindu
+        size = 115
+    }
+
+    soldiers = {
+        culture = assamese
+        religion = secularism
+        size = 2
+    }
+
+    aristocrats = {
+        culture = assamese
+        religion = hindu
+        size = 5826
+    }
+
+    aristocrats = {
+        culture = assamese
+        religion = secularism
+        size = 133
+    }
+
+    artisans = {
+        culture = assamese
+        religion = hindu
+        size = 145
+    }
+
+    artisans = {
+        culture = assamese
+        religion = secularism
+        size = 2
+    }
+
+    capitalists = {
+        culture = assamese
+        religion = hindu
+        size = 727
+    }
+
+    capitalists = {
+        culture = assamese
+        religion = secularism
+        size = 16
+    }
+
+    clergymen = {
+        culture = assamese
+        religion = hindu
+        size = 1456
+    }
+
+    clergymen = {
+        culture = assamese
+        religion = secularism
+        size = 33
+    }
+
+    artisans = {
+        culture = assamese
+        religion = hindu
+        size = 1632
+    }
+
+    artisans = {
+        culture = assamese
+        religion = secularism
+        size = 37
+    }
+
+    farmers = {
+        culture = assamese
+        religion = hindu
+        size = 1717
+    }
+
+    farmers = {
+        culture = assamese
+        religion = secularism
+        size = 38
+    }
+
+    farmers = {
+        culture = naga
+        religion = protestant
+        size = 131117
+    }
+
+    farmers = {
+        culture = naga
+        religion = secularism
+        size = 3017
+    }
 }
 #Tripura - Tripura (1535000/383750 POPS)
 3280 = {
-	officers = {
-		culture = tripuri
-		religion =  hindu 
-		size = 74
-	 } 
-	officers = {
-		culture = tripuri
-		religion = secularism
-		size = 1
-	 } 
-	soldiers = {
-		culture = tripuri
-		religion =  hindu 
-		size = 300
-	 } 
-	soldiers = {
-		culture = tripuri
-		religion = secularism
-		size = 6
-	 } 
-	aristocrats = {
-		culture = tripuri
-		religion =  hindu 
-		size = 15004
-	 } 
-	aristocrats = {
-		culture = tripuri
-		religion = secularism
-		size = 345
-	 } 
-	artisans = {
-		culture = tripuri
-		religion =  hindu 
-		size = 374
-	 } 
-	artisans = {
-		culture = tripuri
-		religion = secularism
-		size = 8
-	 } 
-	capitalists = {
-		culture = tripuri
-		religion =  hindu 
-		size = 1874
-	 } 
-	capitalists = {
-		culture = tripuri
-		religion = secularism
-		size = 43
-	 } 
-	clergymen = {
-		culture = tripuri
-		religion =  hindu 
-		size = 3750
-	 } 
-	clergymen = {
-		culture = tripuri
-		religion = secularism
-		size = 86
-	 } 
-	artisans = {
-		culture = tripuri
-		religion =  hindu 
-		size = 4207
-	 } 
-	artisans = {
-		culture = tripuri
-		religion = secularism
-		size = 96
-	 } 
-	farmers = {
-		culture = tripuri
-		religion =  hindu 
-		size = 75694
-	 } 
-	farmers = {
-		culture = tripuri
-		religion = secularism
-		size = 1742
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion =  protestant 
-		size = 26257
-	 } 
-	farmers = {
-		culture = asian_minor
-		religion = secularism
-		size = 604
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion =  hindu 
-		size = 217566
-	 } 
-	farmers = {
-		culture = bengali_hindu
-		religion = secularism
-		size = 5007
-	 } 
-	farmers = {
-		culture = bengali
-		religion =  sunni 
-		size = 23207
-	 } 
+    officers = {
+        culture = tripuri
+        religion = hindu
+        size = 53
+    }
+
+    officers = {
+        culture = tripuri
+        religion = secularism
+        size = 0
+    }
+
+    soldiers = {
+        culture = tripuri
+        religion = hindu
+        size = 216
+    }
+
+    soldiers = {
+        culture = tripuri
+        religion = secularism
+        size = 4
+    }
+
+    aristocrats = {
+        culture = tripuri
+        religion = hindu
+        size = 10802
+    }
+
+    aristocrats = {
+        culture = tripuri
+        religion = secularism
+        size = 248
+    }
+
+    artisans = {
+        culture = tripuri
+        religion = hindu
+        size = 269
+    }
+
+    artisans = {
+        culture = tripuri
+        religion = secularism
+        size = 5
+    }
+
+    capitalists = {
+        culture = tripuri
+        religion = hindu
+        size = 1349
+    }
+
+    capitalists = {
+        culture = tripuri
+        religion = secularism
+        size = 30
+    }
+
+    clergymen = {
+        culture = tripuri
+        religion = hindu
+        size = 2700
+    }
+
+    clergymen = {
+        culture = tripuri
+        religion = secularism
+        size = 61
+    }
+
+    artisans = {
+        culture = tripuri
+        religion = hindu
+        size = 3029
+    }
+
+    artisans = {
+        culture = tripuri
+        religion = secularism
+        size = 69
+    }
+
+    farmers = {
+        culture = tripuri
+        religion = hindu
+        size = 54499
+    }
+
+    farmers = {
+        culture = tripuri
+        religion = secularism
+        size = 1254
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = protestant
+        size = 18905
+    }
+
+    farmers = {
+        culture = asian_minor
+        religion = secularism
+        size = 434
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = hindu
+        size = 156647
+    }
+
+    farmers = {
+        culture = bengali_hindu
+        religion = secularism
+        size = 3605
+    }
+
+    farmers = {
+        culture = bengali
+        religion = sunni
+        size = 16709
+    }
 }

--- a/CWE/history/pops/1946.1.1/Rajputana.txt
+++ b/CWE/history/pops/1946.1.1/Rajputana.txt
@@ -1,601 +1,710 @@
 #Jaisalmer - Jaisalmer (281000/70250 POPS)
 1265 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 136
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 3
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 549
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 12
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 2746
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 63
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 68
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 1
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 343
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 7
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 686
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 15
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 762
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 17
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 53075
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 1221
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 9212
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 97
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 2
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 395
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 8
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 1977
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 45
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 48
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 0
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 246
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 5
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 493
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 10
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 548
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 12
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 38214
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 879
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 6632
+    }
 }
 #Jodhpur - Jodhpur (4610000/1152500 POPS)
 1266 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 2253
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 51
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 9012
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 207
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 45062
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1037
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1126
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 25
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5632
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 129
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 11265
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 259
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 12521
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 288
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1018462
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 23442
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 1622
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 36
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 6488
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 149
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 32444
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 746
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 810
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 18
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4055
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 92
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 8110
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 186
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 9015
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 207
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 733292
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 16878
+    }
 }
 #Bikaner - Bikaner (3411000/852750 POPS)
 1267 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 1666
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 38
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 6668
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 153
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 33342
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 767
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 832
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 19
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 4167
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 95
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 8335
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 191
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 9264
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 213
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 685929
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 15788
-	 } 
-	farmers = {
-		culture = sikh
-		religion =  sikh 
-		size = 41677
-	 } 
-	farmers = {
-		culture = sikh
-		religion = secularism
-		size = 959
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 26564
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 1199
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 27
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 4800
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 110
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 24006
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 552
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 599
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 13
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3000
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 68
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 6001
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 137
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 6670
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 153
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 493868
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 11367
+    }
+
+    farmers = {
+        culture = sikh
+        religion = sikh
+        size = 30007
+    }
+
+    farmers = {
+        culture = sikh
+        religion = secularism
+        size = 690
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 19126
+    }
 }
 #Jaipur - Jaipur (5579000/1394750 POPS)
 1268 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 2726
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 62
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 10906
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 251
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 54534
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 1255
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1362
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 31
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 6816
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 156
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 13633
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 313
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 15154
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 348
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 1232538
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 28370
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 1962
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 44
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 7852
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 180
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 39264
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 903
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 980
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 22
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 4907
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 112
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 9815
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 225
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 10910
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 250
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 887427
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 20426
+    }
 }
 #Udaipur - Udaipur (4400000/1100000 POPS)
 1269 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 2150
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 49
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 8602
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 198
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 43010
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 990
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1075
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 24
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5376
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 123
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10752
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 247
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11951
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 275
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 972068
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 22374
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 1548
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 35
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 6193
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 142
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 30967
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 712
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 774
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 17
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3870
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 88
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7741
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 177
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8604
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 198
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 699888
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 16109
+    }
 }
 #Tayimba - Kota (2091000/522750 POPS)
 2656 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 1021
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 4087
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 94
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 20439
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 470
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 510
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 11
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 2554
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 58
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 5109
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 117
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 5679
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 130
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 461953
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 10633
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 735
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 2942
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 67
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 14716
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 338
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 367
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 7
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 1838
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 41
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 3678
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 84
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 4088
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 93
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 332606
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 7655
+    }
 }
 #Surinda - Bharatpur (4182000/1045500 POPS)
 2701 = {
-	officers = {
-		culture = indian
-		religion =  hindu 
-		size = 2043
-	 } 
-	officers = {
-		culture = indian
-		religion = secularism
-		size = 47
-	 } 
-	soldiers = {
-		culture = indian
-		religion =  hindu 
-		size = 8175
-	 } 
-	soldiers = {
-		culture = indian
-		religion = secularism
-		size = 188
-	 } 
-	aristocrats = {
-		culture = indian
-		religion =  hindu 
-		size = 40879
-	 } 
-	aristocrats = {
-		culture = indian
-		religion = secularism
-		size = 940
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion =  hindu 
-		size = 1021
-	 } 
-	bureaucrats = {
-		culture = indian
-		religion = secularism
-		size = 23
-	 } 
-	capitalists = {
-		culture = indian
-		religion =  hindu 
-		size = 5109
-	 } 
-	capitalists = {
-		culture = indian
-		religion = secularism
-		size = 117
-	 } 
-	clergymen = {
-		culture = indian
-		religion =  hindu 
-		size = 10219
-	 } 
-	clergymen = {
-		culture = indian
-		religion = secularism
-		size = 235
-	 } 
-	artisans = {
-		culture = indian
-		religion =  hindu 
-		size = 11359
-	 } 
-	artisans = {
-		culture = indian
-		religion = secularism
-		size = 261
-	 } 
-	farmers = {
-		culture = indian
-		religion =  hindu 
-		size = 923907
-	 } 
-	farmers = {
-		culture = indian
-		religion = secularism
-		size = 21266
-	 } 
+    officers = {
+        culture = indian
+        religion = hindu
+        size = 1470
+    }
+
+    officers = {
+        culture = indian
+        religion = secularism
+        size = 33
+    }
+
+    soldiers = {
+        culture = indian
+        religion = hindu
+        size = 5886
+    }
+
+    soldiers = {
+        culture = indian
+        religion = secularism
+        size = 135
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = hindu
+        size = 29432
+    }
+
+    aristocrats = {
+        culture = indian
+        religion = secularism
+        size = 676
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = hindu
+        size = 735
+    }
+
+    bureaucrats = {
+        culture = indian
+        religion = secularism
+        size = 16
+    }
+
+    capitalists = {
+        culture = indian
+        religion = hindu
+        size = 3678
+    }
+
+    capitalists = {
+        culture = indian
+        religion = secularism
+        size = 84
+    }
+
+    clergymen = {
+        culture = indian
+        religion = hindu
+        size = 7357
+    }
+
+    clergymen = {
+        culture = indian
+        religion = secularism
+        size = 169
+    }
+
+    artisans = {
+        culture = indian
+        religion = hindu
+        size = 8178
+    }
+
+    artisans = {
+        culture = indian
+        religion = secularism
+        size = 187
+    }
+
+    farmers = {
+        culture = indian
+        religion = hindu
+        size = 665213
+    }
+
+    farmers = {
+        culture = indian
+        religion = secularism
+        size = 15311
+    }
 }

--- a/CWE/history/pops/1946.1.1/Travancore.txt
+++ b/CWE/history/pops/1946.1.1/Travancore.txt
@@ -1,196 +1,232 @@
 #Cochin - Cochin (6528000/1632000 POPS)
 1318 = {
-	officers = {
-		culture = malayalam
-		religion =  hindu 
-		size = 3190
-	 } 
-	officers = {
-		culture = malayalam
-		religion = secularism
-		size = 73
-	 } 
-	soldiers = {
-		culture = malayalam
-		religion =  hindu 
-		size = 12762
-	 } 
-	soldiers = {
-		culture = malayalam
-		religion = secularism
-		size = 293
-	 } 
-	aristocrats = {
-		culture = malayalam
-		religion =  hindu 
-		size = 63811
-	 } 
-	aristocrats = {
-		culture = malayalam
-		religion = secularism
-		size = 1468
-	 } 
-	bureaucrats = {
-		culture = malayalam
-		religion =  hindu 
-		size = 1595
-	 } 
-	bureaucrats = {
-		culture = malayalam
-		religion = secularism
-		size = 36
-	 } 
-	capitalists = {
-		culture = malayalam
-		religion =  hindu 
-		size = 7976
-	 } 
-	capitalists = {
-		culture = malayalam
-		religion = secularism
-		size = 183
-	 } 
-	clergymen = {
-		culture = malayalam
-		religion =  hindu 
-		size = 15952
-	 } 
-	clergymen = {
-		culture = malayalam
-		religion = secularism
-		size = 367
-	 } 
-	artisans = {
-		culture = malayalam
-		religion =  hindu 
-		size = 17731
-	 } 
-	artisans = {
-		culture = malayalam
-		religion = secularism
-		size = 408
-	 } 
-	farmers = {
-		culture = malayalam
-		religion =  hindu 
-		size = 913911
-	 } 
-	farmers = {
-		culture = malayalam
-		religion = secularism
-		size = 21036
-	 } 
-	farmers = {
-		culture = christian_malayalam
-		religion =  orthodox 
-		size = 398820
-	 } 
-	farmers = {
-		culture = christian_malayalam
-		religion = secularism
-		size = 9180
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 132444
-	 } 
+    officers = {
+        culture = malayalam
+        religion = hindu
+        size = 2296
+    }
+
+    officers = {
+        culture = malayalam
+        religion = secularism
+        size = 52
+    }
+
+    soldiers = {
+        culture = malayalam
+        religion = hindu
+        size = 9188
+    }
+
+    soldiers = {
+        culture = malayalam
+        religion = secularism
+        size = 210
+    }
+
+    aristocrats = {
+        culture = malayalam
+        religion = hindu
+        size = 45943
+    }
+
+    aristocrats = {
+        culture = malayalam
+        religion = secularism
+        size = 1056
+    }
+
+    bureaucrats = {
+        culture = malayalam
+        religion = hindu
+        size = 1148
+    }
+
+    bureaucrats = {
+        culture = malayalam
+        religion = secularism
+        size = 25
+    }
+
+    capitalists = {
+        culture = malayalam
+        religion = hindu
+        size = 5742
+    }
+
+    capitalists = {
+        culture = malayalam
+        religion = secularism
+        size = 131
+    }
+
+    clergymen = {
+        culture = malayalam
+        religion = hindu
+        size = 11485
+    }
+
+    clergymen = {
+        culture = malayalam
+        religion = secularism
+        size = 264
+    }
+
+    artisans = {
+        culture = malayalam
+        religion = hindu
+        size = 12766
+    }
+
+    artisans = {
+        culture = malayalam
+        religion = secularism
+        size = 293
+    }
+
+    farmers = {
+        culture = malayalam
+        religion = hindu
+        size = 658015
+    }
+
+    farmers = {
+        culture = malayalam
+        religion = secularism
+        size = 15145
+    }
+
+    farmers = {
+        culture = christian_malayalam
+        religion = orthodox
+        size = 287150
+    }
+
+    farmers = {
+        culture = christian_malayalam
+        religion = secularism
+        size = 6609
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 95359
+    }
 }
 #Trivandrum - Trivandrum (2482000/620500 POPS)
 1319 = {
-	officers = {
-		culture = malayalam
-		religion =  hindu 
-		size = 1213
-	 } 
-	officers = {
-		culture = malayalam
-		religion = secularism
-		size = 27
-	 } 
-	soldiers = {
-		culture = malayalam
-		religion =  hindu 
-		size = 4852
-	 } 
-	soldiers = {
-		culture = malayalam
-		religion = secularism
-		size = 111
-	 } 
-	aristocrats = {
-		culture = malayalam
-		religion =  hindu 
-		size = 24261
-	 } 
-	aristocrats = {
-		culture = malayalam
-		religion = secularism
-		size = 558
-	 } 
-	bureaucrats = {
-		culture = malayalam
-		religion =  hindu 
-		size = 606
-	 } 
-	bureaucrats = {
-		culture = malayalam
-		religion = secularism
-		size = 13
-	 } 
-	capitalists = {
-		culture = malayalam
-		religion =  hindu 
-		size = 3032
-	 } 
-	capitalists = {
-		culture = malayalam
-		religion = secularism
-		size = 69
-	 } 
-	clergymen = {
-		culture = malayalam
-		religion =  hindu 
-		size = 6065
-	 } 
-	clergymen = {
-		culture = malayalam
-		religion = secularism
-		size = 139
-	 } 
-	artisans = {
-		culture = malayalam
-		religion =  hindu 
-		size = 6741
-	 } 
-	artisans = {
-		culture = malayalam
-		religion = secularism
-		size = 155
-	 } 
-	farmers = {
-		culture = malayalam
-		religion =  hindu 
-		size = 74535
-	 } 
-	farmers = {
-		culture = malayalam
-		religion = secularism
-		size = 1715
-	 } 
-	farmers = {
-		culture = christian_malayalam
-		religion =  orthodox 
-		size = 260811
-	 } 
-	farmers = {
-		culture = christian_malayalam
-		religion = secularism
-		size = 6003
-	 } 
-	farmers = {
-		culture = indian_muslim
-		religion =  sunni 
-		size = 217891
-	 } 
+    officers = {
+        culture = malayalam
+        religion = hindu
+        size = 873
+    }
+
+    officers = {
+        culture = malayalam
+        religion = secularism
+        size = 19
+    }
+
+    soldiers = {
+        culture = malayalam
+        religion = hindu
+        size = 3493
+    }
+
+    soldiers = {
+        culture = malayalam
+        religion = secularism
+        size = 79
+    }
+
+    aristocrats = {
+        culture = malayalam
+        religion = hindu
+        size = 17467
+    }
+
+    aristocrats = {
+        culture = malayalam
+        religion = secularism
+        size = 401
+    }
+
+    bureaucrats = {
+        culture = malayalam
+        religion = hindu
+        size = 436
+    }
+
+    bureaucrats = {
+        culture = malayalam
+        religion = secularism
+        size = 9
+    }
+
+    capitalists = {
+        culture = malayalam
+        religion = hindu
+        size = 2183
+    }
+
+    capitalists = {
+        culture = malayalam
+        religion = secularism
+        size = 49
+    }
+
+    clergymen = {
+        culture = malayalam
+        religion = hindu
+        size = 4366
+    }
+
+    clergymen = {
+        culture = malayalam
+        religion = secularism
+        size = 100
+    }
+
+    artisans = {
+        culture = malayalam
+        religion = hindu
+        size = 4853
+    }
+
+    artisans = {
+        culture = malayalam
+        religion = secularism
+        size = 111
+    }
+
+    farmers = {
+        culture = malayalam
+        religion = hindu
+        size = 53665
+    }
+
+    farmers = {
+        culture = malayalam
+        religion = secularism
+        size = 1234
+    }
+
+    farmers = {
+        culture = christian_malayalam
+        religion = orthodox
+        size = 187783
+    }
+
+    farmers = {
+        culture = christian_malayalam
+        religion = secularism
+        size = 4322
+    }
+
+    farmers = {
+        culture = indian_muslim
+        religion = sunni
+        size = 156881
+    }
 }


### PR DESCRIPTION
Starting populations now:
  Starting PAK: 9.48M pops, 37.93M
  Starting BNG: 11.30M pops, 45.21M
  \^Those were untouched.

**Starting RAJ: 82.9M pops, 331.61M**

All 3 exclude Kashmir, though Kashmir was also changed.

All pops within a HND core province were simply reduced to 72% percent of what they were.
  However, no attention was given to individual provincial populations. Eventually we should check the populations of major Indian cities and make sure they match up to historical values - they seem overinflated.
  The overall population seems alright now, though.