### PR TITLE
More permanent Hungary fix

### DIFF
--- a/CWE/decisions/Globalization.txt
+++ b/CWE/decisions/Globalization.txt
@@ -211,24 +211,30 @@ NOT = { has_global_flag = end_of_bretton_system }
 			NOT = { has_country_flag = market_communism }
 			NOT = { has_country_modifier = comecon_excluded }
 			NOT = { has_country_modifier = bretton_system }
+			NOT = {
+				OR = {
+					is_greater_power = yes
+					is_vassal = no
+				}
+				war = yes
+			}
 		}
 		allow = {
-war = no
 			strd_internet = 1 # i.e 1990+
 			OR = {
 				is_secondary_power = yes
 				is_greater_power = yes
 				sphere_owner = {
-					OR = { 
+					OR = {
 						has_country_modifier = bretton_system 
 						has_country_flag = market_communism
-					} 
+					}
 				}
 				overlord = {
-					OR = { 
-						has_country_modifier = bretton_system 
+					OR = {
+						has_country_modifier = bretton_system
 						has_country_flag = market_communism
-					} 
+					}
 				}
 			}
 		}

--- a/CWE/events/Essential Events 6.txt
+++ b/CWE/events/Essential Events 6.txt
@@ -16,27 +16,3 @@ relation = { who = FROM value = -50 }
 add_country_modifier = { name = currency_manipulation_sanctions duration = -1 }
 		}
 }
-
-#End of the Hungarian Revolution
-country_event = {
-	id = 1412109
-title = "Reintroduction of Communist Rule"
-	desc = "$COUNTRY$ has become a member of the Eastern Bloc once more, hence because of the Brezhnev doctrine, we must have a communist government."
-	picture = "hungarian_communist_gov_change"
-	
-trigger = {
-NOT = { ruling_party_ideology = communist }
-tag = HUN
-war = no
-RUS = { government = proletarian_dictatorship }
-RUS = { is_our_vassal = HUN }
-has_global_flag = blocsenabled
-}
-
-option = {
-name = "The $MONARCHTITLE$ is supreme once more"
-prestige_factor = -0.10
-ruling_party_ideology = communist
-relation = { who = RUS value = 100 }
-		}
-}

--- a/CWE/events/hungarian_revolution_1956.txt
+++ b/CWE/events/hungarian_revolution_1956.txt
@@ -163,7 +163,7 @@ country_event = {
 
   trigger = {
     tag = RUS
-	NOT = { year = 1990 }
+	has_global_flag = blocsenabled
 	war = no
 	is_our_vassal = HUN 
 	has_global_flag = hungarian_revolution_1956
@@ -174,6 +174,10 @@ country_event = {
   option = {
     name = EVT_8501105_A
 	diplomatic_influence = { who = HUN value = 200 }
+	HUN = {
+		prestige_factor = -0.10
+		ruling_party_ideology = communist
+	}
 	country_event = 8225000
   }
 }

--- a/CWE/events/political_great_powers.txt
+++ b/CWE/events/political_great_powers.txt
@@ -911,7 +911,7 @@ country_event = {
                                 FROM = { government = proletarian_dictatorship }
                                 owner = {
                                         civilized = yes
-                                        NOT = { government = proletarian_dictatorship }
+                                        NOT = { ruling_party_ideology = communist }
                                 }
                         }
                         owner = {


### PR DESCRIPTION
Found the bug causing the Hungary problem - the event that fires on a puppet war victory was made before there were multiple communist ideologies. It's been adjusted, and, just in case, the two events to set Hungary back to Soviet have been merged.

Also tweaked market communism to allow at war, but only for vassals. Related to Hungary tangentially.