### PR TITLE
More communist bugfixes

### DIFF
--- a/CWE/decisions/cold_war_alliances.txt
+++ b/CWE/decisions/cold_war_alliances.txt
@@ -45,7 +45,10 @@ add_country_modifier = { name = communist_bloc duration = -1 }
 			factor = 1
 			modifier = {
 				factor = 0
-				ruling_party_ideology = communist_social
+				OR = {
+					ruling_party_ideology = communist_social
+					ruling_party_ideology = socialist
+				}
 			}
 			modifier = {
 				factor = 0

--- a/CWE/events/Essential Events 6.txt
+++ b/CWE/events/Essential Events 6.txt
@@ -122,30 +122,3 @@ prestige = -25
 		}
 
 }
-
-#End of the Hungarian Revolution (Hungary Bug still present)
-country_event = {
-	id = 1412114
-title = "Reintroduction of Communist Rule"
-	desc = "$COUNTRY$ has become a member of the Eastern Bloc once more, hence because of the Brezhnev doctrine, we must have a communist government."
-	picture = "hungarian_communist_gov_change"
-
-fire_only_once = yes
-	
-trigger = {
-NOT = { government = proletarian_dictatorship }
-tag = HUN
-war = no
-RUS = { government = proletarian_dictatorship }
-RUS = { is_our_vassal = HUN }
-has_global_flag = blocsenabled
-}
-
-option = {
-name = "The $MONARCHTITLE$ is supreme once more"
-prestige_factor = -0.10
-government = proletarian_dictatorship
-ruling_party_ideology = communist
-relation = { who = RUS value = 100 }
-		}
-}

--- a/CWE/events/Sovietisation of Eastern Europe.txt
+++ b/CWE/events/Sovietisation of Eastern Europe.txt
@@ -23,6 +23,7 @@ AND = { tag = ALB NOT = { government = proletarian_dictatorship } year = 1946 }
 	name = "Accept the Soviet Demands!"
 		prestige = -20
 	government = proletarian_dictatorship
+	ruling_party_ideology = communist
 	RUS = { create_vassal = THIS }
 	country_event = 800052
 	set_country_flag = sovietee

--- a/CWE/events/communist_plebiscite.txt
+++ b/CWE/events/communist_plebiscite.txt
@@ -631,7 +631,7 @@ country_event = {
 		weaponry = 150
 		relation = { who = FROM value = 20 }
 		random = {
-			chance = 0.10
+			chance = 10
 			FROM = { country_event = 8023334 }
 		}
 	}
@@ -668,7 +668,7 @@ country_event = {
 				factor = 4
 			}
 		}
-		any_country = { limit = { war_with = FROM } relation = -150 }
+		any_country = { limit = { war_with = FROM } relation = { who = THIS value = -150 } }
 	}
 }
 

--- a/CWE/events/occupation_of_austria.txt
+++ b/CWE/events/occupation_of_austria.txt
@@ -112,11 +112,11 @@ country_event = {
   title = "EVT_8203004_NAME" # Lack of recognition
   desc = "EVT_8203004_DESC"
   picture = "nwo2_soviet_occupation_of_austria"
-  is_triggered_only = yes
+  is_triggered_only = yes # AUS
 
   option = {
     name = "EVT_8203004_A"
-	government = proletarian_dictatorship country_event = 800054
+	country_event = 120001
 	AUS = { all_core = { add_core = GER } }
   }
 }

--- a/CWE/events/political_great_powers.txt
+++ b/CWE/events/political_great_powers.txt
@@ -911,7 +911,7 @@ country_event = {
                                 FROM = { government = proletarian_dictatorship }
                                 owner = {
                                         civilized = yes
-                                        NOT = { ruling_party_ideology = communist }
+                                        NOT = { ruling_party_ideology = communist OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
                                 }
                         }
                         owner = {


### PR DESCRIPTION
This should fix the repeated war bug from both Hungary and communist Austria. I've made the fix from last time more lenient in application. Additionally, found a new bug with the Sovietization events - they do not change ideology to communist, thus leading to a problem specifically with Hungary and non-communist Austria, which both start with socialist parties.

Hopefully, that's it. I've removed the event again, and am hoping we won't need it anymore.

Fixed another bug where said Austria would join then immediately leave the eastern bloc

Enabled the ultimate two events in communist_plebiscite from a bad scope

