### PR TITLE
AI logic tweaks + Ethiopia rewrite

### DIFF
--- a/CWE/events/Essential Events 6.txt
+++ b/CWE/events/Essential Events 6.txt
@@ -198,7 +198,7 @@ country_event = {
 		year = 1956
 		NOT = { has_country_modifier = opecmember }
 		NOT = { year = 1990 }
-		OR = { capital_scope = { continent = mena } tag = VNZ }
+		OR = { capital_scope = { continent = mena } owns = 2266 } # Calabozo, VNZ
 		NOT = { has_country_flag = petro_rise }
 		NOT = { government = proletarian_dictatorship }
 		any_owned_province = { trade_goods = petroleum }
@@ -270,7 +270,6 @@ country_event = {
 				OR = {
 					is_core = KEN
 					is_core = TAN
-					# What to do about Zanzibar?
 					is_core = UGA
 					is_core = RWA
 					is_core = BRN

--- a/CWE/events/Essential events 3.txt
+++ b/CWE/events/Essential events 3.txt
@@ -967,32 +967,6 @@ country_event = {
 	}
 }
 
-#Federation of Zanizibar and Tanzania
-country_event = {
-	id = 1400028
-	title = "Formation of the Tanzanian Federation?"
-	desc = EVTDESC1400028
-	picture = "nwo2_tanzania"
-	fire_only_once = yes
-	trigger = {
-		tag = ZAN
-		exists = TAN
-		TAN = { is_vassal = no }
-		ZAN = { is_vassal = no }
-	NOT = { has_country_flag = zanzitan }
-		}
-	option = {
-	name = "Accede!"
-TAN = { inherit = ZAN }
-ai_chance = { factor = 100 }
-			}
-	option = {
-	name = "Remain Independent!"
-	SYR = { set_country_flag = zanzitan }
-	prestige = 10
-	ai_chance = { factor = 0 }
-			}
-	}
 #Election of Trump aka triggering the end of the world
 country_event = {
 	id = 1400029
@@ -1010,37 +984,7 @@ country_event = {
 	set_country_flag = trump
 			}
 	}
-#End the occupation of Ogaden
-country_event = {
-	id = 1400030
-	title = "Issue of the Occupation of the Ogaden"
-	desc = EVTDESC1400030
-	picture = "ogaden"
-	trigger = {
-		tag = ENG
-		1867 = { owned_by = ENG }
-		1866 = { owned_by = ENG }
-		1865 = { owned_by = ENG }
-		year = 1948
-		NOT = { has_country_flag = ethend }
-		}
-	option = {
-	name = "End the occupation!"
-	set_country_flag = ethend
-	prestige = 10
-	1867 = { secede_province = ETH }
-	1866 = { secede_province = ETH }
-	1865 = { secede_province = ETH }
-	ai_chance = { factor = 100 }
-			}
-	option = {
-	name = "Keep the Occupation!"
-	set_country_flag = ethend
-ENG = { diplomatic_influence = { who = ETH value = -200 } }
-	ai_chance = { factor = 0 }
-			}
 
-	}
 #Korean Unification
 country_event = {
 	id = 1400031

--- a/CWE/events/ethiopia.txt
+++ b/CWE/events/ethiopia.txt
@@ -6,20 +6,29 @@ country_event = {
 	fire_only_once = yes
 
 	trigger = {
-		tag = ENG
+		capital_scope = { continent = europe } # ENG or FBU
 		NOT = { exists = ERI }
 		exists = ETH
 		war = no
-		1848 = { controlled_by = ENG } # Assmara
+		owns = 1848 # Assmara
 	}
 
 	mean_time_to_happen = {
 		months = 18
+		modifier = {
+			factor = 0.1
+			any_owned_province = {
+				is_core = ERI
+				OR = {
+					has_province_modifier = nationalist_agitation
+					controlled_by_rebels = yes
+				}
+			}
+		}
 	}
 
 	option = {
-		name = EVT_1005301_A 
-		ai_chance = { factor = 100 }
+		name = EVT_1005301_A
 		prestige = -2
 		any_pop = {
 			limit = {
@@ -29,22 +38,46 @@ country_event = {
 			militancy = 2
 		}
 		release = ERI
-		ERI = { government = absolute_monarchy country_event = 800050  }
-		ETH = { create_vassal = ERI }
+		random_country = { limit = { tag = ETH OR = { government = absolute_monarchy government = hms_government government = hms_government1 } } ERI = { government = absolute_monarchy country_event = 800050 } }
+		diplomatic_influence = { who = ERI value = 100 }
+		ETH = {
+			create_vassal = ERI
+			sphere_owner = { diplomatic_influence = { who = ERI value = 100 } }
+		}
+		ai_chance = {
+			factor = 0.9
+			modifier = {
+				factor = 0.1
+				ETH = { ruling_party_ideology = communist }
+			}
+			modifier = {
+				factor = 0.25
+				ruling_party_ideology = populist
+			}
+		}
 	}
-	
+
 	option = {
-		name = EVT_1005301_B 
-		ai_chance = { factor = 0 }
+		name = EVT_1005301_B
 		relation = { who = ETH value = -100 }
 		diplomatic_influence = { who = ETH value = -100 }
 		release_vassal = ERI
-ENG = { diplomatic_influence = { who = ERI value = 200 } }
+		diplomatic_influence = { who = ERI value = 200 }
+		ai_chance = {
+			factor = 0.1
+			modifier = {
+				factor = 5
+				NOT = { relation = { who = ETH value = 0 } }
+			}
+			modifier = {
+				factor = 0.25
+				ruling_party_ideology = populist
+			}
+		}
 	}
 
 	option = {
 		name = EVT_1005301_C
-		ai_chance = { factor = 0 }
 		any_pop = {
 			limit = {
 				OR = { culture = tigre culture = afar }
@@ -53,20 +86,32 @@ ENG = { diplomatic_influence = { who = ERI value = 200 } }
 			militancy = 8
 		}
 		badboy = 10
-		add_country_modifier = { name = denied_independence duration = 365 }
+		any_owned = {
+			limit = { is_core = ERI }
+			add_province_modifier = {
+				name = nationalist_agitation
+				duration = 1095
+			}
+		}
+		ai_chance = {
+			factor = 0.01
+			modifier = {
+				factor = 0
+				badboy = 0.6
+			}
+		}
 	}
 
 }
 
 country_event = {
 	id = 1005302
-
 	title = EVT_1005302_NAME
 	desc = EVT_1005302_DESC
 	picture = "haile_selassie"
 
 	fire_only_once = yes
-	
+
 	trigger = {
 		tag = ETH
 		exists = ERI
@@ -76,11 +121,13 @@ country_event = {
 
 	mean_time_to_happen = {
 		months = 48 # TODO depend on ETH reforms
+		modifier = {
+			factor = 2
+		}
 	}
 
 	option = {
-		name = EVT_1005302_A 
-		ai_chance = { factor = 100 }
+		name = EVT_1005302_A
 		badboy = 4
 		any_pop = {
 			limit = {
@@ -89,12 +136,23 @@ country_event = {
 			consciousness = 2
 			militancy = 8
 		}
-		ERI = {annex_to = THIS }
+		ERI = {
+			annex_to = THIS
+			all_core = {
+				add_province_modifier = { name = nationalist_agitation duration = 1095 }
+			}
+		}
+		ai_chance = {
+			factor = 1
+			modifier = {
+				factor = 0
+				badboy = 0.84
+			}
+		}
 	}
-	
+
 	option = {
-		name = EVT_1005302_B 
-		ai_chance = { factor = 0 }
+		name = EVT_1005302_B
 		any_pop = {
 			limit = {
 				OR = { culture = tigre culture = tigray }
@@ -102,129 +160,290 @@ country_event = {
 			consciousness = 2
 			militancy = 5
 		}
+		ai_chance = {
+			factor = 0.1
+		}
+	}
+
+}
+
+# Ethiopian government change - possibilities
+# 1. Reform into a constitutional monarchy
+# 2. Constitutional coup
+# 3. Communist coup
+# 4. Hold out until 1990
+
+country_event = {
+	id = 8005303
+	title = EVT_8005303_NAME
+	desc = EVT_8005303_DESC
+	picture = "nwo2_haile_selassie_old"
+	fire_only_once = yes
+
+	trigger = {
+		tag = ETH
+		year = 1960 NOT = { year = 1990 }
+		government = absolute_monarchy
+	}
+
+	mean_time_to_happen = {
+		months = 96
+		modifier = {
+			factor = 0.75
+			part_of_sphere = yes
+			sphere_owner = { government = democracy }
+		}
+		modifier = {
+			factor = 0.75
+			ruling_party_ideology = liberal
+		}
+		modifier = {
+			factor = 0.5
+			ruling_party_ideology = progressive
+		}
+		modifier = {
+			factor = 0.8
+			average_consciousness = 4
+		}
+		modifier = {
+			factor = 0.8
+			OR = {
+				pop_majority_ideology = liberal
+				pop_majority_ideology = progressive
+			}
+		}
+		modifier = {
+			factor = 0.9
+			capital_scope = {
+				OR = {
+					pop_majority_ideology = liberal
+					pop_majority_ideology = progressive
+				}
+			}
+		}
+	}
+
+	immediate = {
+		government = hms_government # Prevent simultaneous coup events
+	}
+
+	option = {
+		name = EVT_8005303_A
+		define_general = { name = "Amha Selassie" personality = energetic background = no_background }
+		country_event = 800044
+		any_pop = {
+			limit = {
+				type = soldiers
+				type = officers
+			}
+			militancy = 3
+			consciousness = 3
+		}
+		any_pop = {
+			scaled_militancy = {
+				ideology = traditionalist
+				factor = 4
+			}
+			scaled_consciousness = {
+				ideology = traditionalist
+				factor = 4
+			}
+			scaled_militancy = {
+				ideology = conservative
+				factor = 2
+			}
+			scaled_consciousness = {
+				ideology = conservative
+				factor = 2
+			}
+		}
+	}
+}
+country_event = {
+	id = 8005305
+	title = EVT_8005305_NAME
+	desc = EVT_8005305_DESC
+	picture = "nwo2_derg"
+	fire_only_once = yes
+
+	trigger = {
+		tag = ETH
+		year = 1960 NOT = { year = 1990 }
+		government = absolute_monarchy
+		NOT = { has_country_flag = derg }
+	}
+
+	mean_time_to_happen = {
+		months = 96
+		modifier = {
+			factor = 0.75
+			part_of_sphere = yes
+			sphere_owner = { government = proletarian_dictatorship }
+		}
+		modifier = {
+			factor = 1.2
+			ruling_party_ideology = socialist
+		}
+		modifier = {
+			factor = 0.5
+			ruling_party_ideology = communist
+		}
+		modifier = {
+			factor = 0.75
+			ruling_party_ideology = communist_social
+		}
+		modifier = {
+			factor = 0.8
+			average_consciousness = 4
+		}
+		modifier = {
+			factor = 0.8
+			OR = {
+				pop_majority_ideology = socialist
+				pop_majority_ideology = communist
+				pop_majority_ideology = communist_social
+			}
+		}
+		modifier = {
+			factor = 0.9
+			capital_scope = {
+				OR = {
+					pop_majority_ideology = socialist
+					pop_majority_ideology = communist
+					pop_majority_ideology = communist_social
+				}
+			}
+		}
+	}
+
+	immediate = {
+		government = proletarian_dictatorship
+	}
+
+	option = {
+		name = EVT_8005305_A
+		country_event = 800042
+		set_country_flag = derg
+		random_state = { any_pop = { dominant_issue = { value = planned_economy factor = 0.15 } } }
+		ai_chance = { factor = 0 }
 	}
 
 }
 country_event = {
-  id = 8005303
-  title = EVT_8005303_NAME
-  desc = EVT_8005303_DESC
-  picture = "nwo2_haile_selassie_old"
-  fire_only_once = yes
+	id = 8005309
+	title = EVT_8005309_NAME
+	desc = EVT_8005309_DESC
+	picture = "nwo2_fall_of_derg"
+	fire_only_once = yes
 
-  trigger = {
-    tag = ETH
-    year = 1960 NOT = { year = 1961 }
-    government = absolute_monarchy
-  }
+	trigger = {
+		has_country_flag = derg # ETH
+		NOT = { any_greater_power = { has_country_modifier = communist_bloc_leader } } # End of the Cold War
+		government = proletarian_dictatorship
+	}
 
-  mean_time_to_happen = { months = 1 }
+	mean_time_to_happen = { months = 1 }
 
-  option = {
-    name = EVT_8005303_A
-	any_pop = { consciousness = 1 }
-	ai_chance = { factor = 100 }
-  }
+	immediate = {
+		clr_country_flag = derg
+	}
 
-  option = {
-    name = EVT_8005303_B
-	define_general = { name = " Amha Selassie" personality = energetic background = no_background }
-	government = hms_government country_event = 800054 
-	ai_chance = { factor = 0 }
-  }
+	option = {
+		name = EVT_8005309_A
+		government = democracy country_event = 800054
+		random_state = { any_pop = { dominant_issue = { value = parties_allowed factor = 0.15 } } }
+		release = ERI
+		ai_chance = { factor = 100 }
+	}
+
+	option = {
+		name = EVT_8005309_B
+		any_pop = { militancy = 5.0 }
+		country_event = 8023300 # communist_plebiscite.txt
+		ai_chance = { factor = 0 }
+	}
 }
 country_event = {
-  id = 8005305
-  title = EVT_8005305_NAME
-  desc = EVT_8005305_DESC
-  picture = "nwo2_derg"
-  fire_only_once = yes
+	id = 8005312
+	title = EVT_8005312_NAME
+	desc = EVT_8005312_DESC
+	picture = "nwo2_eritrea"
+	fire_only_once = yes
 
-  trigger = {
-    tag = ETH
-	year = 1960 NOT = { year = 1974 }
-  }
+	trigger = {
+		tag = ETH
+		year = 1961
+		is_possible_vassal = ERI
+		NOT = { accepted_culture = tigre }
+	}
 
-  mean_time_to_happen = { months = 8 }
+	mean_time_to_happen = { months = 9 }
 
-  option = {
-    name = EVT_8005305_A
-	government = proletarian_dictatorship country_event = 800052
-	random_state = { any_pop = { dominant_issue = { value = planned_economy factor = 0.15 } } }
-	ai_chance = { factor = 0 }
-  }
-
-  option = {
-    name = EVT_8005305_B
-	any_pop = { militancy = 3.0 }
-	government = hms_government country_event = 800054
-	random_state = { any_pop = { dominant_issue = { value = planned_economy factor = 0.19 } } }
-	country_event =  { id = 8005306 days = 360 } 
-	ai_chance = { factor = 100 }
-  }
+	option = {
+		name = EVT_8005312_A
+		any_owned = {
+			limit = {
+				is_core = ERI
+				OR = {
+					is_primary_culture = ERI
+					is_accepted_culture = ERI
+					# All but Assab
+				}
+			}
+			any_pop = {
+				militancy = 5
+				ideology = {
+					factor = 0.5
+					value = nationalist
+				}
+			}
+		}
+	}
 }
+
+#End the occupation of Ogaden
 country_event = {
-  id = 8005306
-  title = EVT_8005306_NAME
-  desc = EVT_8005306_DESC
-  picture = "nwo2_derg"
-  is_triggered_only = yes
+	id = 8005306
+	title = EVT_8005306_NAME
+	desc = EVTDESC1400030
+	picture = "ogaden"
+	fire_only_once = yes
 
-  option = {
-    name = EVT_8005306_A
-	government = proletarian_dictatorship country_event = 800052
-	relation = { who = USA value = -150 } 
-	relation = { who = ENG value = -150 } 
-	relation = { who = RUS value = 150 } 
-  }
+	mean_time_to_happen = {
+		months = 24
+	}
+
+	trigger = {
+		capital_scope = { continent = europe } # ENG or FBU
+		any_owned_province = { is_core = ETH }
+		NOT = { war_with = ETH }
+	}
+
+	option = {
+		name = EVT_8005306_A
+		prestige = 10
+		release = ETH
+		ai_chance = {
+			factor = 0.5
+			modifier = {
+				factor = 1.5
+				ETH = { in_sphere = THIS }
+			}
+		}
+	}
+
+	option = {
+		name = EVT_8005306_B
+		ETH_1865 = { add_core = SML }
+		diplomatic_influence = { who = ETH value = -200 }
+		random_country = { limit = { tag = ETH NOT = { government = proletarian_dictatorship } } USA = { relation = { who = THIS value = -50 } } } # America is unhappy unless ETH is communist
+		ai_chance = {
+			factor = 0.5
+			modifier = {
+				factor = 2
+				NOT = { relation = { who = USA value = 0 } }
+			}
+		}
+	}
+
 }
-country_event = {
-  id = 8005309
-  title = EVT_8005309_NAME
-  desc = EVT_8005309_DESC
-  picture = "nwo2_fall_of_derg"
-  fire_only_once = yes
-
-  trigger = {
-    tag = ETH
-	year = 1991 NOT = { year = 1999 }
-    government = proletarian_dictatorship
-  }
-
-  mean_time_to_happen = { months = 1 }
-
-  option = {
-    name = EVT_8005309_A
-	government = democracy country_event = 800054
-	random_state = { any_pop = { dominant_issue = { value = parties_allowed factor = 0.15 } } }
-	release = ERI
-	ai_chance = { factor = 100 }
-  }
-
-  option = {
-    name = EVT_8005309_B
-	any_pop = { militancy = 5.0 }
-	ai_chance = { factor = 0 }
-  }
-}
-country_event = {
-  id = 8005312
-  title = EVT_8005312_NAME
-  desc = EVT_8005312_DESC
-  picture = "nwo2_eritrea"
-  fire_only_once = yes
-
-  trigger = {
-    tag = ETH
-    year = 1961 NOT = { year = 1963 }
-    any_owned_province = { province_id = 1848 }  
-  }
-
-  mean_time_to_happen = { months = 1 }
-
-  option = {
-    name = EVT_8005312_A
-	1848 = { any_pop = { militancy = 5 } }1849 = { any_pop = { militancy = 5 } }1850 = { any_pop = { militancy = 5 } }
-  }
-}
-

--- a/CWE/events/somalia.txt
+++ b/CWE/events/somalia.txt
@@ -6,12 +6,14 @@ country_event = { # Trust Territory of Somaliland
   fire_only_once = yes
 
   trigger = {
-    tag = ENG
+    capital_scope = { continent = europe } # ENG or FBU
 	owns = 1869
-	year = 1949 NOT = { year = 1990 }
+	NOT = { year = 1990 }
   }
 
-  mean_time_to_happen = { months = 1 }
+	mean_time_to_happen = {
+		months = 12
+	}
 
   option = {
     name = EVT_8014100_A
@@ -37,7 +39,7 @@ country_event = {
   option = {
     name = EVT_8014101_A
 	release_vassal = SOM
-	ENG = { diplomatic_influence = { who = SOM value = 200 } }
+	1873 = { owner = { diplomatic_influence = { who = SOM value = 200 } } } # Berbera, ENG
 	create_vassal = SOM # some strange bug makes SOM UK vassal!!
 	SOM = { government = hms_government } # country_event = 800054 }
   }
@@ -81,6 +83,7 @@ country_event = {
   option = {
     name = EVT_8014103_B
 	release = SML
+	any_owned = { limit = { is_core = ETH } secede_province = SML } # In case Ogaden Occupation event never fired
 	badboy = 2
 	prestige = -5
 	diplomatic_influence = { who = SML value = 200 }

--- a/CWE/events/trieste.txt
+++ b/CWE/events/trieste.txt
@@ -42,13 +42,28 @@ country_event = {
   fire_only_once = yes
 
   trigger = {
-	tag = YUG
+	OR = {
+		769 = { # Postojna; YUG, SLO, BKF, etc.
+			owner = {
+				OR = {
+					AND = { # Regular Yugoslavia
+						tag = THIS
+						is_vassal = no
+					}
+					AND = { # Yugoslavia released Slovenia, but not USSR with vassal Yugoslavia
+						is_vassal = yes
+						overlord = { tag = THIS }
+						NOT = { owns = 794 } # Belgrade
+					}
+				}
+			}
+		}
+	}
 	year = 1954 NOT = { year = 1990 }
-	NOT = { YUG = { war_with = ITA } }
+	NOT = { war_with = ITA }
 	exists = TRE
 	USA = { is_our_vassal = TRE }
 	TRE = { ai = yes }
-	TRE = { is_vassal = yes }
   }
 
   mean_time_to_happen = { months = 9 }
@@ -101,6 +116,7 @@ country_event = {
 			factor = 0
 			part_of_sphere = yes
 			sphere_owner = { OR = { tag = ITA tag = USA } }
+			NOT = { ruling_party_ideology = populist }
 		}
 	}
   }
@@ -139,15 +155,54 @@ country_event = {
   option = {
     name = EVT_8020303_A
 	any_pop = { militancy = 0.3  consciousness = 1.0 }
+	ai_chance = {
+		factor = 0.5
+		modifier = {
+			factor = 0
+			FROM = { ai = no }
+			ITA = { ai = yes }
+		}
+	}
   }
 
   option = {
-    name = EVT_8020303_B
-	YUG = { country_event = 8020304 }
+	name = EVT_8020303_B
+	FROM = { country_event = 8020304 }
 	any_pop = { militancy = 0.5  consciousness = 0.5 }
-	relation = { who = YUG value = 100 } 
+	relation = { who = FROM value = 100 } 
 	relation = { who = ITA value = -100 } 
-	relation = { who = RUS value = 25 } 
+	relation = { who = RUS value = 25 }
+	ai_chance = {
+		factor = 0.5
+		modifier = {
+			factor = 0.1
+			ruling_party_ideology = populist
+		}
+		modifier = {
+			factor = 0.5
+			NOT = { relation = { who = FROM value = 0 } }
+		}
+		modifier = {
+			factor = 1.5
+			NOT = { relation = { who = ITA value = 50 } }
+		}
+		modifier = {
+			factor = 2
+			FROM = { has_country_modifier = neutrality }
+		}
+		modifier = {
+			factor = 2
+			ITA = { has_country_modifier = neutrality }
+		}
+		modifier = {
+			factor = 2
+			ITA = { ruling_party_ideology = communist }
+		}
+		modifier = {
+			factor = 3
+			NOT = { FROM = { ruling_party_ideology = communist } }
+		}
+	}
   }
 }
 country_event = {
@@ -161,10 +216,13 @@ country_event = {
   option = {
     name = EVT_8020304_A
 	inherit = TRE
-	736 = {
-		add_core = SLO
-		change_province_name = "Trst"
+	any_country = {
+		limit = {
+			is_core = 769 # Postojna; SLO, YUG, BKF, etc.
+		}
+		add_core = 736
 	}
+	736 = { change_province_name = "Trst" }
 	any_owned = { remove_core = TRE }
   }
 }

--- a/CWE/events/united_balkans.txt
+++ b/CWE/events/united_balkans.txt
@@ -202,7 +202,7 @@ country_event = {
   title = EVT_8216021_NAME
   desc = EVT_8216021_DESC
   picture = "nwo2_united_balkans"
-  is_triggered_only = yes
+  is_triggered_only = yes # BUL
 
   option = {
     name = EVT_8216021_A
@@ -226,7 +226,7 @@ country_event = {
   title = EVT_8216022_NAME
   desc = EVT_8216022_DESC
   picture = "nwo2_bulgaria_in_yugoslavia"
-  is_triggered_only = yes
+  is_triggered_only = yes # YUG
 
   option = {
     name = EVT_8216022_A #"We invite people of Bulgaria"
@@ -250,23 +250,30 @@ country_event = {
   title = EVT_8216023_NAME
   desc = EVT_8216023_DESC
   picture = "nwo2_bulgaria_in_yugoslavia"
-  is_triggered_only = yes
+  is_triggered_only = yes # RUS
 
   option = {
     name = EVT_8216023_A #"No"
-	ai_chance = { factor = 0.6 }
 	relation = { who = BUL value = -50 } 
 	relation = { who = YUG value = -50 } 
+	ai_chance = {
+		factor = 0.6
+		modifier = {
+			factor = 0 # TEMPORARY measure to avoid unnecessary savescum
+			FROM = { ai = no }
+			BUL = { ai = yes }
+		}
+	}
   }
 
   option = {
     name = EVT_8216023_B #"Let them"
-	ai_chance = { factor = 0.4 }
 	prestige = -10
 	diplomatic_influence = { who = YUG value = -100 } 
 	relation = { who = BUL value = 50 } 
 	relation = { who = YUG value = 50 } 
 	BUL = { country_event =  { id = 8216024 days = 30 } }
+	ai_chance = { factor = 0.4 }
   } 
 }
 country_event = {
@@ -274,7 +281,7 @@ country_event = {
   title = EVT_8216024_NAME
   desc = EVT_8216024_DESC
   picture = "nwo2_bulgaria_in_yugoslavia"
-  is_triggered_only = yes
+  is_triggered_only = yes # BUL
 
   option = {
     name = EVT_8216024_A

--- a/CWE/localisation/nwo_events.csv
+++ b/CWE/localisation/nwo_events.csv
@@ -1711,17 +1711,15 @@ EVT_8005022_NAME;Miners' strikes;;;;;;;;;;X
 EVT_8005022_DESC;Thatcher was committed to reducing the power of the trade unions, whose leadership she accused of undermining parliamentary democracy and economic performance through strike action. Several unions launched strikes in response to legislation introduced to curb their power, but resistance eventually collapsed. Only 39 percent of union members voted for Labour in the 1983 general election. According to the BBC, Thatcher 'managed to destroy the power of the trade unions for almost a generation'.;;;;;;;;;;X
 EVT_8005022_A;We will not cave in!;;;;;;;;;;X
 EVT_8005022_B;Give some concessions;;;;;;;;;;X
-EVT_8005303_NAME;1960 Ethiopian Coup;;;;;;;;;;X
-EVT_8005303_DESC;While Emperor Haile Selassie was away on a state visit, conspirators took hostage several important personages and after taking control of most of Addis Ababa, they declared the emperor deposed and announced more progressive government under the rule of Haile Selassie's eldest son, Asfaw Wossen. Despite support of the students of Haile Selassie University, military units remained loyal and worked together to crush the coup.;;;;;;;;;;X
-EVT_8005303_A;The coup is crushed;;;;;;;;;;X
-EVT_8005303_B;The coup succeeds;;;;;;;;;;X
+EVT_8005303_NAME;$YEAR$ Ethiopian Coup;;;;;;;;;;X
+EVT_8005303_DESC;While Emperor Haile Selassie was away on a state visit, conspirators took several important personages hostages and, after taking control of most of Addis Ababa, they declared the emperor deposed and announced a more progressive government under the rule of Haile Selassie's eldest son, Asfaw Wossen. Despite support of the students of Haile Selassie University, military units remained loyal and worked together against the coup.;;;;;;;;;;X
+EVT_8005303_A;The coup succeeds;;;;;;;;;;X
 EVT_8005305_NAME;Ethiopian Revolution of 1974;;;;;;;;;;X
-EVT_8005305_DESC;In 1961 the 30-year Eritrean struggle for independence began, following the Ethiopian Emperor Haile Selassie I's dissolution of the federation and shutting down the Eritrean parliament.;;;;;;;;;;X
+EVT_8005305_DESC;After a period of civil unrest which began in February 1974, the aging Emperor Haile Selassie I was removed from his position. On September 12, 1974, a provisional administrative council of soldiers, known as the Derg ('committee') seized power from the emperor and installed a government which was socialist in name and military in style. The Derg summarily executed 59 members of the former government, including two former Prime Ministers and Crown Councilors, Court officials, ministers, and generals. Emperor Haile Selassie died on August 22, 1975. He was allegedly strangled in the basement of his palace or smothered with a wet pillow.;;;;;;;;;;X
 EVT_8005305_A;Derg takes the power and removes Haile Selassie;;;;;;;;;;X
-EVT_8005305_B;Revolutionaries take power but thei radicalism is limited;;;;;;;;;;X
-EVT_8005306_NAME;Derg regime;;;;;;;;;;X
-EVT_8005306_DESC;After a period of civil unrest which began in February 1974, the aging Emperor Haile Selassie I was removed from his position. On September 12, 1974, a provisional administrative council of soldiers, known as the Derg ('committee') seized power from the emperor and installed a government which was socialist in name and military in style. The Derg summarily executed 59 members of the former government, including two former Prime Ministers and Crown Councilors, Court officials, ministers, and generals. Emperor Haile Selassie died on August 22, 1975. He was allegedly strangled in the basement of his palace or smothered with a wet pillow.;;;;;;;;;;X
-EVT_8005306_A;OK;;;;;;;;;;X
+EVT_8005306_NAME;Issue of the Occupation of the Ogaden;;;;;;;;;;X
+EVT_8005306_A;End the occupation;;;;;;;;;;X
+EVT_8005306_B;We will grant self-determination to the Somali people;;;;;;;;;;X
 EVT_8005309_NAME;Fall of Derg;;;;;;;;;;X
 EVT_8005309_DESC;"Throughout all the years, thousands of suspected enemies of the Derg were tortured and/or killed in a purge called the 'Red Terror'. Communism was officially adopted during the late 1970s and early 1980s;;;;;;;;;;X
 EVT_8005309_A;Bring down the regime!;;;;;;;;;;X


### PR DESCRIPTION
Something I've put in but am iffy about is having the issue of Trieste and Bulgarian unification autoresolve in favor of the player if no other players are nations involved. The way I see it, players are probably savescumming those events anyway. The Bulgarian unification one is temporary until the ^pending Yugoslavia rewrite, anyway.

I've read two separate complaints about the fixed nature of Ethiopian events, so I've rewritten them. Now, there's both a liberal and communist coup possible, with MTTHs based on the political climate of the country but otherwise equal. Only one of them will fire, and it is possible to avoid them by reforming into a constitutional monarchy or getting very lucky with the MTTHs until 1990. I've also rewritten some Somalia events so that the Ogaden becomes Somalian about 1/4th of the time. I've cleaned up Eritrean events to match the general changes we've been making to decolonization events, though there's one event I'd like to tweak in the future some more.