### PR TITLE
UNSQ duplicate event fix and limits

### DIFF
--- a/CWE/events/Essential Events 4.txt
+++ b/CWE/events/Essential Events 4.txt
@@ -2361,54 +2361,51 @@ country_event = {
 	}
 	option = {
 		name = EVT_1412086_A # "Let's see who got the job"
-
-		random_country = {
-			limit = {
-				has_country_modifier = united_nations_ga_member
-				NOT = { has_country_modifier = unsc_permanent_member }
-				NOT = { badboy = 1 }
-			}
-			country_event = 1412087
-		}
-
 		random_list = {
 			25 = { 
-				#Aggressive
-				country_event = 1412088
-			} 
+				random_country = {
+					limit = {
+						has_country_modifier = united_nations_ga_member
+						NOT = { has_country_modifier = unsc_permanent_member }
+						war = no
+						NOT = { badboy = 1 }
+					}
+					country_event = 1412088
+				}
+			}
 			50 = { 
 				#Normal
-				country_event = 1412089
+				random_country = {
+					limit = {
+						has_country_modifier = united_nations_ga_member
+						NOT = { has_country_modifier = unsc_permanent_member }
+						war = no
+						NOT = { badboy = 1 }
+					}
+					country_event = 1412089
+				}
 			}
 			25 = { 
 				#Passive
-				country_event = 1412090
+				random_country = {
+					limit = {
+						has_country_modifier = united_nations_ga_member
+						NOT = { has_country_modifier = unsc_permanent_member }
+						war = no
+						NOT = { badboy = 1 }
+					}
+					country_event = 1412090
+				}
 			}
 		}
 	}
 }
 
-
-#Select UN Secretary General
-country_event = {
-	id = 1412087
-	title = EVT_1412087_NAME # "Our Candidate for UN Secretary-General Selected!"
-	desc = EVT_1412086_DESC
-	picture = "UNSG_Selection"
-	is_triggered_only = yes
-	major = yes
-
-	option = {
-		name = EVT_1412087_A # "Every Secretary-General shapes the office"
-		prestige = 50
-		badboy = -5
-	}
-}
 
 #Select Aggressive UN Secretary General
 country_event = {
 	id = 1412088
-	title = EVT_1412088_NAME # "Proactive UN Secretary-General Selected"
+	title = EVT_1412087_NAME # "Our Candidate for UN Secretary-General Selected!"
 	desc = EVT_1412088_DESC # "The new UN Secretary-General does not subscribe to non-interventionism, nor to acting only with the General Assembly's support, going so far as to believe that the office of Secretary-General should have independence of action. We can expect strong sanctions against warring nations."
 	picture = "UNSG_aggressive"
 	is_triggered_only = yes
@@ -2419,16 +2416,29 @@ country_event = {
 		clr_global_flag = UNSG_aggressive
 		clr_global_flag = UNSG_normal
 		clr_global_flag = UNSG_passive
-
 		set_global_flag = UNSG_aggressive
-		any_country = { any_pop = { consciousness = 0.9 } }
+		any_country = {
+			limit = {
+				exists = yes
+				OR = {
+					AND = {
+						is_vassal = yes
+						overlord = { has_country_modifier = united_nations_ga_member }
+					}
+					has_country_modifier = united_nations_ga_member
+				}
+			}
+			any_pop = { consciousness = 0.9 }
+		}
+		prestige = 50
+		badboy = -5
 	}
 }
 
 #Select Normal UN Secretary General
 country_event = {
 	id = 1412089
-	title = EVT_1412089_NAME # "Uninspiring UN Secretary-General Selected"
+	title = EVT_1412087_NAME
 	desc = EVT_1412089_DESC # "The new UN Secretary-General usually subscribes to non-interventionism and to acting with the General Assembly's support. At best, we can expect weak sanctions against warring nations."
 	picture = "UNSG_normal"
 	is_triggered_only = yes
@@ -2439,16 +2449,29 @@ country_event = {
 		clr_global_flag = UNSG_aggressive
 		clr_global_flag = UNSG_normal
 		clr_global_flag = UNSG_passive
-
 		set_global_flag = UNSG_normal
-		any_country = { any_pop = { consciousness = 0.6 } }
+		any_country = {
+			limit = {
+				exists = yes
+				OR = {
+					AND = {
+						is_vassal = yes
+						overlord = { has_country_modifier = united_nations_ga_member }
+					}
+					has_country_modifier = united_nations_ga_member
+				}
+			}
+			any_pop = { consciousness = 0.6 }
+		}
+		prestige = 35
+		badboy = -5
 	}
 }
 
 #Select Passive UN Secretary General
 country_event = {
 	id = 1412090
-	title = EVT_1412090_NAME # "Passive UN Secretary-General Selected"
+	title = EVT_1412087_NAME
 	desc = EVT_1412090_DESC # "The new UN Secretary-General subscribes completely to non-interventionism and to acting only with the General Assembly's support. We can expect warring nations to largely go unpunished."
 	picture = "UNSG_passive"
 	is_triggered_only = yes
@@ -2459,9 +2482,22 @@ country_event = {
 		clr_global_flag = UNSG_aggressive
 		clr_global_flag = UNSG_normal
 		clr_global_flag = UNSG_passive
-
 		set_global_flag = UNSG_passive
-		any_country = { any_pop = { consciousness = 0.3 } }
+		any_country = {
+			limit = {
+				exists = yes
+				OR = {
+					AND = {
+						is_vassal = yes
+						overlord = { has_country_modifier = united_nations_ga_member }
+					}
+					has_country_modifier = united_nations_ga_member
+				}
+			}
+			any_pop = { consciousness = 0.3 }
+		}
+		prestige = 20
+		badboy = -5
 	}
 }
 

--- a/CWE/localisation/United Nations.csv
+++ b/CWE/localisation/United Nations.csv
@@ -4,13 +4,10 @@ EVT_1412086_DESC;Article 97 of the United Nations Charter determines that the Se
 EVT_1412086_A;Let's see who got the job;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412087_NAME;Our Candidate for UN Secretary-General Selected!;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412087_A;Every Secretary-General shapes the office;;;;;;;;x;;;;;;;;;;;;;
-EVT_1412088_NAME;Proactive UN Secretary-General Selected;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412088_DESC;The new UN Secretary-General does not subscribe to non-interventionism, nor to acting only with the General Assembly's support, going so far as to believe that the office of Secretary-General should have independence of action. We can expect strong sanctions against warring nations.;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412088_A;That 'organisation' had better not meddle in our affairs!;;;;;;;;x;;;;;;;;;;;;;
-EVT_1412089_NAME;Uninspiring UN Secretary-General Selected;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412089_DESC;The new UN Secretary-General usually subscribes to non-interventionism and to acting with the General Assembly's support. At best, we can expect weak sanctions against warring nations.;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412089_A;Who is this, even?;;;;;;;;x;;;;;;;;;;;;;
-EVT_1412090_NAME;Passive UN Secretary-General Selected;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412090_DESC;The new UN Secretary-General subscribes completely to non-interventionism and to acting only with the General Assembly's support. We can expect warring nations to largely go unpunished.;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412090_A;What a joke;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412092_NAME;UN sanctions imposed against our nation;;;;;;;;x;;;;;;;;;;;;;

--- a/CWE/localisation/United Nations.csv
+++ b/CWE/localisation/United Nations.csv
@@ -4,11 +4,11 @@ EVT_1412086_DESC;Article 97 of the United Nations Charter determines that the Se
 EVT_1412086_A;Let's see who got the job;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412087_NAME;Our Candidate for UN Secretary-General Selected!;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412087_A;Every Secretary-General shapes the office;;;;;;;;x;;;;;;;;;;;;;
-EVT_1412088_DESC;The new UN Secretary-General does not subscribe to non-interventionism, nor to acting only with the General Assembly's support, going so far as to believe that the office of Secretary-General should have independence of action. We can expect strong sanctions against warring nations.;;;;;;;;x;;;;;;;;;;;;;
+EVT_1412088_DESC;Proactive UN Secretary-General Selected\n\nThe new UN Secretary-General does not subscribe to non-interventionism, nor to acting only with the General Assembly's support, going so far as to believe that the office of Secretary-General should have independence of action. We can expect strong sanctions against warring nations.;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412088_A;That 'organisation' had better not meddle in our affairs!;;;;;;;;x;;;;;;;;;;;;;
-EVT_1412089_DESC;The new UN Secretary-General usually subscribes to non-interventionism and to acting with the General Assembly's support. At best, we can expect weak sanctions against warring nations.;;;;;;;;x;;;;;;;;;;;;;
+EVT_1412089_DESC;Uninspiring UN Secretary-General Selected\n\nThe new UN Secretary-General usually subscribes to non-interventionism and to acting with the General Assembly's support. At best, we can expect weak sanctions against warring nations.;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412089_A;Who is this, even?;;;;;;;;x;;;;;;;;;;;;;
-EVT_1412090_DESC;The new UN Secretary-General subscribes completely to non-interventionism and to acting only with the General Assembly's support. We can expect warring nations to largely go unpunished.;;;;;;;;x;;;;;;;;;;;;;
+EVT_1412090_DESC;Passive UN Secretary-General Selected\n\nThe new UN Secretary-General subscribes completely to non-interventionism and to acting only with the General Assembly's support. We can expect warring nations to largely go unpunished.;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412090_A;What a joke;;;;;;;;x;;;;;;;;;;;;;
 EVT_1412092_NAME;UN sanctions imposed against our nation;;;;;;;;x;;;;;;;;;;;;;
 un_sanctions_strong_desc;The United Nations Secretary-General has imposed strong sanctions on our nation, hoping to persuade us to seek peace.;;;;;;;;x;;;;;;;;;;;;;


### PR DESCRIPTION
Limits referring to only countries at peace getting the UNSG event and only UN members of vassals of such getting the global consciousness. Also tweaked the prestige values a little and minor cleanup.

Tested this - it does select all three kinds of secetaries-general and there is only one major event per selection.