### PR TITLE
Proposal for communist ISI name change

### DIFF
--- a/CWE/localisation/countries.csv
+++ b/CWE/localisation/countries.csv
@@ -17,6 +17,25 @@ DRZ;Druze;x
 DRZ_ADJ;Jabalian;x
 HOU;Houthis;Houthis;Huthi;;Houthis;;;;;;;;;x;;;;;;;;;;;;;;;;
 HOU_ADJ;Houthi;;;;;;;;;;;;;x;;;;;;;;;;;;;;;;
+ISI;The Islamic Republic;;;;;;;x
+ISI_proletarian_dictatorship;The Anti-Imperialist State;;;;;;;x
+ISI_theocracy;The Islamic State;;;;;;;x
+ISI_ADJ;Islamic;;;;;;;x
+ISI_proletarian_dictatorship_ADJ;Anti-Imperialist;;;;;;;x
+ISR_hms_government;The Dominion of Israel;Israël;Israel;;Israel;;;;;;;;x;;;;;;;;;;;;;;;;;
+ISR;Israel;Israël;Israel;;Israel;;;;;;;;x;;;;;;;;;;;;;;;;;
+ISR_ADJ;Israeli;israélien;Israelitisch;;Israelí;;;;;;;;x;;;;;;;;;;;;;;;;;
+ICB_ADJ;Berliner;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+ICB;International City of Berlin;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+SCS_ADJ;Asian;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+SCS;South China Sea Islands International Zone;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+FBU_hms_government_ADJ;British-French;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+FBU_ADJ;Commonwealth;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+FBU;The United Commonwealth Federation;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+FBU_proletarian_dictatorship;Commonwealth of People's Republics;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+FBU_hms_government;The United Kingdom of Britain and France;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+JRU_ADJ;Jerusalite;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
+JRU;International City of Jerusalem;;;;;;;;;;;;x;;;;;;;;;;;;;;;;;
 MSU;Mosul;Mossoul;Mossul;Mosul;Mosul;;;;;;;;;x;;;;;;;;;;;;;;;;
 MSU_ADJ;Moswali;;;;;;;;;;;;;x;;;;;;;;;;;;;;;;
 TGZ;Tangier;Tanger;Tanger;;Tánger;;;;;;;;;x;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The Anti-Imperialist State - remove references to religion while still giving another unifying ideal to the areas it claims