### PR TITLE
ManCan civil war fixes

### DIFF
--- a/CWE/common/event_modifiers.txt
+++ b/CWE/common/event_modifiers.txt
@@ -327,8 +327,9 @@ joint_aid = {
 	tax_efficiency = -0.05
 }
 
-### Religion Flag ###
+### Flag ###
 religion_flag = { icon = 4 }
+capital_flag = { icon = 4 }
 
 ### Special Drawing Rights ###
 

--- a/CWE/events/manchurian_candidate.txt
+++ b/CWE/events/manchurian_candidate.txt
@@ -118,7 +118,15 @@ country_event = {
 
 	option = {
 		name = MANCAN_4_A
-		any_country = { limit = { exists = no any_core = { owned_by = THIS } } country_event = 112907 }
+		capital_scope = { add_province_modifier = { name = capital_flag duration = 2 } }
+		any_country = {
+			limit = {
+				exists = no
+				any_core = { owned_by = THIS }
+				NOT = { any_core = { has_province_modifier = capital_flag } }
+			}
+			country_event = 112907
+		}
 
 		any_country = { limit = { in_sphere = THIS } diplomatic_influence = { who = THIS value = -100 } }
 
@@ -132,6 +140,8 @@ country_event = {
 					capital	= 387 # Brussels
 					capital	= 375 # Amesterdam
 					capital	= 397 # Luxembourg
+					capital	= 2468 # Sydney
+					owns	= 1657 # Kyoto
 				}
 				OR = {
 					government = democracy


### PR DESCRIPTION
If the Manchurian Candidate chain were used on a nation with all of their cores also the cores of another nation, such as a not-yet-formed superstate, the first nation would be completely dissolved. This is fixed.  
It may be advisable to replace the code for releasing countries with the code for dismantlement at some point, as this already avoids the issue by leaving the capital state intact. However, this works fine for now.

Another problem with the chain would arise if the UN headquarters were to be moved, but all of the eligible provinces in Europe are part of a superstate dictatorship. Two more possible locations for the headquarters have been added, one in Asia and one in Oceania.