### PR TITLE
Set some decisions on game start

### DIFF
--- a/CWE/history/countries/ARG - Argentina.txt
+++ b/CWE/history/countries/ARG - Argentina.txt
@@ -46,6 +46,8 @@ social_service_reform = no_social_service
 # Starting Consciousness
 consciousness = 5
 nonstate_consciousness = 0
+decision = united_nations
+decision = jointheunga
 schools = army_tech_school
 oob = "/ARG_oob.txt"
 

--- a/CWE/history/countries/AST - Australia.txt
+++ b/CWE/history/countries/AST - Australia.txt
@@ -50,6 +50,8 @@ social_service_reform = no_social_service
 consciousness = 1
 nonstate_consciousness = 1
 schools = ENG_1_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/AST_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/BEL - Belgium.txt
+++ b/CWE/history/countries/BEL - Belgium.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 1
 nonstate_consciousness = 1
 schools = industrial_tech_school 
+decision = united_nations
+decision = jointheunga
 oob = "/BEL_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/BOL - Bolivia.txt
+++ b/CWE/history/countries/BOL - Bolivia.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/BOL_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/BRZ - Brazil.txt
+++ b/CWE/history/countries/BRZ - Brazil.txt
@@ -48,6 +48,8 @@ social_service_reform = social_services
 # Starting Consciousness
 consciousness = 0
 nonstate_consciousness = 0
+decision = united_nations
+decision = jointheunga
 schools = army_tech_school
 oob = "/BRZ_oob.txt"
 

--- a/CWE/history/countries/CAN - Canada.txt
+++ b/CWE/history/countries/CAN - Canada.txt
@@ -76,6 +76,8 @@ command_of_the_sea = 1
 consciousness = 1
 nonstate_consciousness = 1
 schools = ENG_1_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/CAN_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/CHL - Chile.txt
+++ b/CWE/history/countries/CHL - Chile.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/CHL_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/CLM - Colombia.txt
+++ b/CWE/history/countries/CLM - Colombia.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/CLM_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/COS - Costa Rica.txt
+++ b/CWE/history/countries/COS - Costa Rica.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/COS_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/CUB - Cuba.txt
+++ b/CWE/history/countries/CUB - Cuba.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 1
 nonstate_consciousness = 1
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/CUB_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/DEN - Denmark.txt
+++ b/CWE/history/countries/DEN - Denmark.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 2
 nonstate_consciousness = 2
 schools = commerce_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/DEN_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/DOM - Dominican Republic.txt
+++ b/CWE/history/countries/DOM - Dominican Republic.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/DOM_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/ECU - Ecuador.txt
+++ b/CWE/history/countries/ECU - Ecuador.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/ECU_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/EGY - Egypt.txt
+++ b/CWE/history/countries/EGY - Egypt.txt
@@ -71,6 +71,8 @@ command_of_the_sea = 1
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/EGY_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/ELS - El Salvador.txt
+++ b/CWE/history/countries/ELS - El Salvador.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/ELS_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/ENG - United Kingdom.txt
+++ b/CWE/history/countries/ENG - United Kingdom.txt
@@ -84,6 +84,9 @@ sea_denial_strategy = 1
 consciousness = 1
 nonstate_consciousness = 1
 schools = ENG_tech_school
+decision = united_nations
+decision = jointheunga
+decision = jointheunsc
 oob = "/ENG_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/ETH - Ethiopia.txt
+++ b/CWE/history/countries/ETH - Ethiopia.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/ETH_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/FRA - France.txt
+++ b/CWE/history/countries/FRA - France.txt
@@ -81,6 +81,9 @@ sea_denial_strategy = 1
 consciousness = 1
 nonstate_consciousness = 1
 schools = FRA_tech_school
+decision = united_nations
+decision = jointheunga
+decision = jointheunsc
 oob = "/FRA_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/GRE - Greece.txt
+++ b/CWE/history/countries/GRE - Greece.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = industrial_tech_school 
+decision = united_nations
+decision = jointheunga
 oob = "/GRE_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/GUA - Guatemala.txt
+++ b/CWE/history/countries/GUA - Guatemala.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/GUA_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/HAI - Haiti.txt
+++ b/CWE/history/countries/HAI - Haiti.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/HAI_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/HON - Honduras.txt
+++ b/CWE/history/countries/HON - Honduras.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/HON_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/IRQ - Iraq.txt
+++ b/CWE/history/countries/IRQ - Iraq.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/IRQ_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/JAP - Japan.txt
+++ b/CWE/history/countries/JAP - Japan.txt
@@ -71,6 +71,7 @@ command_of_the_sea = 1
 # Starting Consciousness
 consciousness = 1
 nonstate_consciousness = 1
+decision = renounce_war_right
 schools = industrial_tech_school
 oob = "/JAP_oob.txt"
 1992.1.1 = {

--- a/CWE/history/countries/KMT - Republic of China.txt
+++ b/CWE/history/countries/KMT - Republic of China.txt
@@ -58,6 +58,9 @@ social_service_reform = no_social_service
 consciousness = 1
 nonstate_consciousness = 1
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
+decision = jointheunsc
 oob = "/KMT_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/LEB - Lebanon.txt
+++ b/CWE/history/countries/LEB - Lebanon.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/LEB_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/LIB - Liberia.txt
+++ b/CWE/history/countries/LIB - Liberia.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/LIB_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/LUX - Luxemburg.txt
+++ b/CWE/history/countries/LUX - Luxemburg.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 1
 nonstate_consciousness = 1
 schools = commerce_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/LUX_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/MEX - Mexico.txt
+++ b/CWE/history/countries/MEX - Mexico.txt
@@ -73,6 +73,8 @@ command_of_the_sea = 1
 consciousness = 1
 nonstate_consciousness = 1
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/MEX_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/NET - Netherlands.txt
+++ b/CWE/history/countries/NET - Netherlands.txt
@@ -72,6 +72,8 @@ command_of_the_sea = 1
 consciousness = 1
 nonstate_consciousness = 1
 schools = industrial_tech_school 
+decision = united_nations
+decision = jointheunga
 oob = "/NET_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/NIC - Nicaragua.txt
+++ b/CWE/history/countries/NIC - Nicaragua.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/NIC_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/NOR - Norway.txt
+++ b/CWE/history/countries/NOR - Norway.txt
@@ -72,6 +72,8 @@ command_of_the_sea = 1
 consciousness = 2
 nonstate_consciousness = 2
 schools = industrial_tech_school 
+decision = united_nations
+decision = jointheunga
 oob = "/NOR_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/NZL - New Zealand.txt
+++ b/CWE/history/countries/NZL - New Zealand.txt
@@ -49,6 +49,8 @@ social_service_reform = no_social_service
 consciousness = 1
 nonstate_consciousness = 1
 schools = ENG_1_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/NZL_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/PER - Persia.txt
+++ b/CWE/history/countries/PER - Persia.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/PER_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/PEU - Peru.txt
+++ b/CWE/history/countries/PEU - Peru.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/PEU_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/PNM - Panama.txt
+++ b/CWE/history/countries/PNM - Panama.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/PNM_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/POL - Poland.txt
+++ b/CWE/history/countries/POL - Poland.txt
@@ -72,6 +72,8 @@ command_of_the_sea = 1
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/POL_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/PRG - Paraguay.txt
+++ b/CWE/history/countries/PRG - Paraguay.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/PRG_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/RUS - Russia.txt
+++ b/CWE/history/countries/RUS - Russia.txt
@@ -85,6 +85,10 @@ consciousness = 1
 nonstate_consciousness = 1
 
 decision = develop_the_atomic_bomb
+decision = centralhigh
+decision = united_nations
+decision = jointheunga
+decision = jointheunsc
 
 schools = army_tech_school
 oob = "/RUS_oob.txt"

--- a/CWE/history/countries/SAA - Saudi Arabia.txt
+++ b/CWE/history/countries/SAA - Saudi Arabia.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/SAA_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/SAF - South Africa.txt
+++ b/CWE/history/countries/SAF - South Africa.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = industrial_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/SAF_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/SYR - Syria.txt
+++ b/CWE/history/countries/SYR - Syria.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = mandate
+decision = united_nations
+decision = jointheunga
 oob = "/SYR_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/URU - Uruguay.txt
+++ b/CWE/history/countries/URU - Uruguay.txt
@@ -47,6 +47,8 @@ social_service_reform = no_social_service
 consciousness = 1
 nonstate_consciousness = 1
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/URU_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/USA - USA.txt
+++ b/CWE/history/countries/USA - USA.txt
@@ -87,6 +87,9 @@ sea_denial_strategy = 1
 consciousness = 0
 nonstate_consciousness = 0
 schools = industrial_tech_school
+decision = united_nations
+decision = jointheunga
+decision = jointheunsc
 oob = "/USA_oob.txt"
 
 1992.1.1 = {

--- a/CWE/history/countries/VNZ - Venezuela.txt
+++ b/CWE/history/countries/VNZ - Venezuela.txt
@@ -48,6 +48,8 @@ social_service_reform = no_social_service
 consciousness = 0
 nonstate_consciousness = 0
 schools = army_tech_school
+decision = united_nations
+decision = jointheunga
 oob = "/VNZ_oob.txt"
 
 1992.1.1 = {


### PR DESCRIPTION
All UN members, Japan's right to war, and Soviet centralization

This also sets some members which can not join under the current mechanics, such as Cuba, who was a member but is represented as a vassal, and Ukraine and Belarus, who will automatically be members on independence as their respective SSRs joined the UN.

Something that may be wise to check - I made the Republic of China a UNSC member on game start, as it was by 1946. Hopefully, there exists something to remove this when it becomes Taiwan. If not, it can be easily added.

If this works well, I'll probably see about setting more things like this. I particularly like automatically renouncing the right to war for Japan, as otherwise there is no reason for the player to do so.