### PR TITLE
Tweak decisions for over 25 infamy, fixes

### DIFF
--- a/CWE/decisions/Climate Change.txt
+++ b/CWE/decisions/Climate Change.txt
@@ -2,45 +2,46 @@ political_decisions = {
 
 
 join_ipcc = {
-		picture = "ipcc_member"
-		potential = {
-	has_global_flag = ipcc
-	is_vassal = no
-	NOT = { has_country_modifier = ipcc_member }
-						}
-		allow = {
-			war = no
-			election = no
-				}
-	effect = {
-prestige = 5
-add_country_modifier = { name = ipcc_member duration = -1 }
-}
-		ai_will_do = { 
-			factor = 100 
-			}
+	picture = "ipcc_member"
+	potential = {
+		has_global_flag = ipcc
+		is_vassal = no
+		NOT = { has_country_modifier = ipcc_member }
+		NOT = { badboy = 1 }
 	}
+	allow = {
+		war = no
+		election = no
+	}
+	effect = {
+		prestige = 5
+		add_country_modifier = { name = ipcc_member duration = -1 }
+	}
+	ai_will_do = {
+		factor = 1
+	}
+}
 
 montreal_protocol = {
-		picture = "montreal_protocol"
-		potential = {
-	neoliberalism = 1
-	year = 1987
-	has_global_flag = montreal_start
-	NOT = { has_country_modifier = montreal_protocol }
-						}
-		allow = {
-			war = no
-			election = no
-				}
-	effect = {
-prestige = 5
-add_country_modifier = { name = montreal_protocol duration = -1 }
-}
-		ai_will_do = { 
-			factor = 100 
-			}
+	picture = "montreal_protocol"
+	potential = {
+		neoliberalism = 1
+		has_global_flag = montreal_start # 1987
+		NOT = { has_country_modifier = montreal_protocol }
+		NOT = { badboy = 1 }
 	}
+	allow = {
+		war = no
+		election = no
+	}
+	effect = {
+		prestige = 5
+		add_country_modifier = { name = montreal_protocol duration = -1 }
+	}
+	ai_will_do = {
+		factor = 1
+	}
+}
 
 kyoto_protocol = {
 		picture = "kyoto_protocol"

--- a/CWE/decisions/IMF vs Foreign Power Loans.txt
+++ b/CWE/decisions/IMF vs Foreign Power Loans.txt
@@ -1,134 +1,141 @@
 political_decisions = {
 
-stop_loan = {
+	stop_loan = {
 		picture = "stop_loan"
-	potential = {
-OR = { has_country_modifier = creditor_nation num_of_vassals = 1 }
-NOT = { has_country_flag = stop_loan }
+		potential = {
+			OR = { has_country_modifier = creditor_nation num_of_vassals = 1 }
+			NOT = { has_country_flag = stop_loan }
 		}
-alert = no
-	allow = {
-
-					}
+		alert = no
+		allow = { }
 		effect = {
-set_country_flag = stop_loan
+			set_country_flag = stop_loan
 		}
-		ai_will_do = { 
-			factor = 0 
-			}
+		ai_will_do = {
+			factor = 0
+		}
 	}
 
-start_loan = {
+	start_loan = {
 		picture = "start_loan"
-	potential = {
-has_country_flag = stop_loan
+		potential = {
+			has_country_flag = stop_loan
 		}
-alert = no
-	allow = {
-
-					}
+		alert = no
+		allow = { }
 		effect = {
-clr_country_flag = stop_loan
+			clr_country_flag = stop_loan
 		}
-		ai_will_do = { 
-			factor = 1 
-			}
+		ai_will_do = {
+			factor = 1
+		}
 	}
 
-imf_loan = {
+	imf_loan = {
 		picture = "imf_loan"
-	potential = {
-year = 1947
-election = no
-war = no
-NOT = { has_country_modifier = imf_loan_requested }
-NOT = { has_country_modifier = imf_loan }
-NOT = { has_country_modifier = overlord_loan_requested }
-NOT = { has_country_modifier = foreign_loan_requested }
-NOT = { money = 55000 }
+		potential = {
+			year = 1947
+			election = no
+			war = no
+			NOT = { has_country_modifier = imf_loan_requested }
+			NOT = { has_country_modifier = imf_loan }
+			NOT = { has_country_modifier = overlord_loan_requested }
+			NOT = { has_country_modifier = foreign_loan_requested }
+			NOT = { money = 55000 }
+			NOT = { badboy = 1 }
 		}
-	allow = {
-		election = no
-		war = no
-OR = { ai = no AND = { ai = yes NOT = { money = 50000 } } }
-			}
+		allow = {
+			election = no
+			war = no
+		}
 		effect = {
 			prestige = -25
-money = 50000
-add_country_modifier = { name = imf_loan duration = 3650 }
+			money = 50000
+			add_country_modifier = { name = imf_loan duration = 3650 }
 
 		}
-		ai_will_do = { 
-			factor = 1 
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				money = 50000
 			}
+		}
 	}
 
-overlord_loan = {
+	overlord_loan = {
 		picture = "overlord_loan"
-	potential = {
-is_secondary_power = no
-is_greater_power = no
-OR = { in_sphere = THIS
-is_vassal = yes }
-election = no
-war = no
-NOT = { has_country_modifier = overlord_loan_requested }
-NOT = { has_country_modifier = imf_loan_requested }
-NOT = { has_country_modifier = foreign_loan_requested }
-NOT = { money = 60000 } 
-		}
-	allow = {
-		election = no
-		war = no
-OR = { 
-overlord = { NOT = { has_country_flag = stop_loan } AND = { is_vassal = no money = 1000000 } }
-any_greater_power = { AND = { is_sphere_leader_of = THIS money = 1000000 } } 
-}
-OR = { ai = no AND = { ai = yes NOT = { money = 50000 } } }
+		potential = {
+			is_secondary_power = no
+			is_greater_power = no
+			OR = {
+				part_of_sphere = yes
+				is_vassal = yes
 			}
+			election = no
+			war = no
+			NOT = { has_country_modifier = overlord_loan_requested }
+			NOT = { has_country_modifier = imf_loan_requested }
+			NOT = { has_country_modifier = foreign_loan_requested }
+			NOT = { money = 60000 }
+		}
+		allow = {
+			election = no
+			war = no
+			OR = {
+				overlord = { NOT = { has_country_flag = stop_loan } AND = { is_vassal = no money = 1000000 } }
+				any_greater_power = { AND = { is_sphere_leader_of = THIS money = 1000000 } }
+			}
+		}
 		effect = {
-random_country = { limit = { NOT = { has_country_flag = stop_loan } OR = { is_sphere_leader_of = THIS AND = { is_our_vassal = THIS is_vassal = no } } } country_event = 624912 }
-prestige = -15
-add_country_modifier = { name = overlord_loan_requested duration = 1825 }
-
+			random_country = { limit = { NOT = { has_country_flag = stop_loan } OR = { is_sphere_leader_of = THIS AND = { is_our_vassal = THIS is_vassal = no } } } country_event = 624912 }
+			prestige = -15
+			add_country_modifier = { name = overlord_loan_requested duration = 1825 }
 		}
-		ai_will_do = { 
-			factor = 1 
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				money = 50000
 			}
+		}
 	}
 
-foreign_loan = {
-picture = "foreign_loan"
-potential = {
-year = 1947
-election = no
-is_greater_power = no
-is_secondary_power = no
-war = no
-NOT = { has_country_modifier = foreign_loan_requested }
-NOT = { has_country_modifier = overlord_loan_requested }
-NOT = { has_country_modifier = imf_loan_requested }
-NOT = { money = 30000 } 
+	foreign_loan = {
+		picture = "foreign_loan"
+		potential = {
+			year = 1947
+			election = no
+			is_greater_power = no
+			is_secondary_power = no
+			war = no
+			NOT = { has_country_modifier = foreign_loan_requested }
+			NOT = { has_country_modifier = overlord_loan_requested }
+			NOT = { has_country_modifier = imf_loan_requested }
+			NOT = { money = 30000 }
+			NOT = { badboy = 1 }
 		}
-	allow = {
-		election = no
-		war = no
-NOT = { any_greater_power = { NOT = { money = 750000 } } }
-NOT = { in_sphere = THIS }
-is_vassal = no
-		is_greater_power = no
-		is_secondary_power = no
-OR = { ai = no AND = { ai = yes NOT = { money = 25000 } } }
-			}
+		allow = {
+			election = no
+			war = no
+			any_greater_power = { money = 750000 }
+			part_of_sphere = no
+			is_vassal = no
+			is_greater_power = no
+			is_secondary_power = no
+		}
 		effect = {
-any_country = { limit = { NOT = { has_country_flag = stop_loan } has_country_modifier = creditor_nation } country_event = 624914 }
-prestige = -20
-add_country_modifier = { name = foreign_loan_requested duration = 1825 }
-
+			any_country = { limit = { NOT = { has_country_flag = stop_loan } has_country_modifier = creditor_nation } country_event = 624914 }
+			prestige = -20
+			add_country_modifier = { name = foreign_loan_requested duration = 1825 }
 		}
-		ai_will_do = { 
-			factor = 1 
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				money = 25000
 			}
+		}
 	}
 
 

--- a/CWE/decisions/International Development Association.txt
+++ b/CWE/decisions/International Development Association.txt
@@ -1,25 +1,26 @@
 political_decisions = {
-jointheida = {
+	jointheida = {
 		picture = "jointheida"
 		potential = {
-		year = 1949
-		NOT = { government = proletarian_dictatorship }
-		NOT = { has_country_modifier = ida_member }
-		has_global_flag = idaformed
+			year = 1949
+			NOT = { government = proletarian_dictatorship }
+			NOT = { has_country_modifier = ida_member }
+			has_global_flag = idaformed
+			NOT = { badboy = 1 }
 		}
 		allow = {
 			election = no
 			war = no
-				}
+		}
 		effect = {
 			prestige = 10
-add_country_modifier = { name = ida_member duration = -1 }
+			add_country_modifier = { name = ida_member duration = -1 }
 		}
-		ai_will_do = { 
-			factor = 1 
-			}
+		ai_will_do = {
+			factor = 1
+		}
 	}
-leavetheida = {
+	leavetheida = {
 		picture = "jointheida"
 		potential = {
 			government = proletarian_dictatorship
@@ -29,38 +30,41 @@ leavetheida = {
 		allow = {
 			war = no
 			election = no
-				}
+		}
 		effect = {
 			prestige = -20
-	remove_country_modifier = ida_member
-			}
-		ai_will_do = { 
-			factor = 1 
-			}
+			remove_country_modifier = ida_member
+		}
+		ai_will_do = {
+			factor = 1
+		}
 	}
-ida_loan = {
+	ida_loan = {
 		picture = "ida_loan"
-	potential = {
-election = no
-war = no
-NOT = { rank = 100 }
-has_country_modifier = ida_member
-NOT = { has_country_modifier = ida_loan }
+		potential = {
+			election = no
+			war = no
+			NOT = { rank = 100 }
+			has_country_modifier = ida_member
+			NOT = { has_country_modifier = ida_loan }
 		}
-	allow = {
-		election = no
-		war = no
-OR = { ai = no AND = { ai = yes NOT = { money = 100000 } } }
-			}
+		allow = {
+			election = no
+			war = no
+		}
 		effect = {
-prestige = -5
-money = 10000
-add_country_modifier = { name = ida_loan duration = 1825 }
-any_country = { limit = { AND = { rank = 100 has_country_modifier = ida_member } } relation = { who = THIS value = -10 } }
+			prestige = -5
+			money = 10000
+			add_country_modifier = { name = ida_loan duration = 1825 }
+			any_country = { limit = { AND = { rank = 100 has_country_modifier = ida_member } } relation = { who = THIS value = -10 } }
 		}
-		ai_will_do = { 
-			factor = 1 
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				money = 100000
 			}
+		}
 	}
 
 

--- a/CWE/decisions/International Organisations decisions.txt
+++ b/CWE/decisions/International Organisations decisions.txt
@@ -2,8 +2,9 @@ political_decisions = {
 	jointheimf = {
 		picture = "jointheimf"
 		potential = {
-			NOT = { government = proletarian_dictatorship }
+			NOT = { ruling_party_ideology = communist }
 			NOT = { has_country_modifier = imf_member }
+			NOT = { badboy = 1 }
 		}
 		allow = {
 			war = no
@@ -19,9 +20,10 @@ political_decisions = {
 	jointheibrd = {
 		picture = "jointheibrd"
 		potential = {
-			NOT = { government = proletarian_dictatorship }
+			NOT = { ruling_party_ideology = communist }
 			NOT = { has_country_modifier = ibrd_member }
 			year = 1947
+			NOT = { badboy = 1 }
 		}
 		allow = {
 			war = no
@@ -38,16 +40,17 @@ political_decisions = {
 	jointhewto = {
 		picture = "jointhewto"
 		potential = {
-			NOT = { government = proletarian_dictatorship }
+			NOT = { ruling_party_ideology = communist }
 			NOT = { has_country_modifier = wto_member }
 			year = 1995
+			NOT = { badboy = 1 }
 		}
 		allow = {
 			war = no
 		}
 		effect = {
 			prestige = 10
-set_country_flag = wto_member_flag
+			set_country_flag = wto_member_flag
 			add_country_modifier = { name = wto_member duration = -1 }
 		}
 		ai_will_do = { 

--- a/CWE/decisions/Islamic Development Bank.txt
+++ b/CWE/decisions/Islamic Development Bank.txt
@@ -1,48 +1,48 @@
 political_decisions = {
-formtheidb = {
-	picture = "jointheidb"
-		potential = {
-		tag = SAA
-		primary_culture = sunni_arab
-		is_vassal = no
-		NOT = { has_country_modifier = idb_member }
-		}
-		allow = {
-		war = no
-		capitalism = 1
-		NOT = { government = proletarian_dictatorship }
-		NOT = { government = nationalist_dictatorship }
-		NOT = { government = populist_dictatorship }
-		}
-		effect = {
-		prestige = 25
-		set_global_flag = idbformed
-add_country_modifier = { name = idb_member duration = -1 }add_country_modifier = { name = idb_chairmanship duration = -1 }
-		}
-		ai_will_do = { 
-			factor = 100 
-			}
-	}
-jointheidb = {
+	formtheidb = {
 		picture = "jointheidb"
 		potential = {
-		primary_culture = sunni_arab
-		NOT = { has_country_modifier = idb_member }
-		has_global_flag = idbformed
+			tag = SAA
+			primary_culture = sunni_arab
+			is_vassal = no
+			NOT = { has_country_modifier = idb_member }
 		}
 		allow = {
-			NOT = { government = proletarian_dictatorship }
 			war = no
-				}
+			capitalism = 1
+			NOT = { government = proletarian_dictatorship }
+			NOT = { government = nationalist_dictatorship }
+			NOT = { government = populist_dictatorship }
+		}
+		effect = {
+			prestige = 25
+			set_global_flag = idbformed
+			add_country_modifier = { name = idb_member duration = -1 }add_country_modifier = { name = idb_chairmanship duration = -1 }
+		}
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	jointheidb = {
+		picture = "jointheidb"
+		potential = {
+			has_country_modifier = oic_member
+			NOT = { has_country_modifier = idb_member }
+			has_global_flag = idbformed
+		}
+		allow = {
+			NOT = { religious_policy = pro_atheism }
+			war = no
+		}
 		effect = {
 			prestige = 10
-add_country_modifier = { name = idb_member duration = -1 }
+			add_country_modifier = { name = idb_member duration = -1 }
 		}
-		ai_will_do = { 
-			factor = 1 
-			}
+		ai_will_do = {
+			factor = 1
+		}
 	}
-leavetheidb = {
+	leavetheidb = {
 		picture = "jointheidb"
 		potential = {
 			OR = { government = proletarian_dictatorship NOT = { primary_culture = sunni_arab } }
@@ -51,46 +51,46 @@ leavetheidb = {
 		}
 		allow = {
 			war = no
-				}
+		}
 		effect = {
 			pretige = -20
-	remove_country_modifier = idb_member
-	remove_country_modifier = idbhigh
+			remove_country_modifier = idb_member
+			remove_country_modifier = idbhigh
 			remove_country_modifier = idbmedium
 			remove_country_modifier = idblow
 			clr_country_flag = idbhigh
 			clr_country_flag = idbmedium
 			clr_country_flag = idblow
 		}
-		ai_will_do = { 
-			factor = 1 
-			}
+		ai_will_do = {
+			factor = 1
+		}
 	}
 
 
 
 
-changeidb = {
+	changeidb = {
 		picture = "jointheidb"
 		potential = {
 			has_country_modifier = idb_chairmanship
-	OR = { has_country_modifier = idbhigh_gp
-			has_country_modifier = idbmedium_gp
-			has_country_modifier = idblow_gp }
-			}
-alert = no
+			OR = { has_country_modifier = idbhigh_gp
+				has_country_modifier = idbmedium_gp
+				has_country_modifier = idblow_gp }
+		}
+		alert = no
 		allow = {
 			war = no
-OR = { ai = no AND = { ai = yes OR = { 
+			OR = { ai = no AND = { ai = yes OR = {
 
-AND = { has_global_flag = idbhigh NOT = { OR = { economic_policy = state_capitalism economic_policy = planned_economy } } } 
+						AND = { has_global_flag = idbhigh NOT = { OR = { economic_policy = state_capitalism economic_policy = planned_economy } } }
 
-AND = { has_global_flag = idbmedium NOT = { economic_policy = interventionism } } 
+						AND = { has_global_flag = idbmedium NOT = { economic_policy = interventionism } }
 
-AND = { has_global_flag = idblow NOT = { economic_policy = laissez_faire } } 
+						AND = { has_global_flag = idblow NOT = { economic_policy = laissez_faire } }
 
-} } } 
-				}
+					} } }
+		}
 		effect = {
 			remove_country_modifier = idbhigh_gp
 			remove_country_modifier = idbmedium_gp
@@ -101,99 +101,99 @@ AND = { has_global_flag = idblow NOT = { economic_policy = laissez_faire } }
 			clr_global_flag = idbhigh
 			clr_global_flag = idbmedium
 			clr_global_flag = idblow
-any_country = { limit = { has_country_modifier = idb_member } 
-			remove_country_modifier = idbhigh
-			remove_country_modifier = idbmedium
-			remove_country_modifier = idblow
-			clr_country_flag = idbhigh
-			clr_country_flag = idbmedium
-			clr_country_flag = idblow
-}
-		}
-		ai_will_do = { 
-			factor = 100 
+			any_country = { limit = { has_country_modifier = idb_member }
+				remove_country_modifier = idbhigh
+				remove_country_modifier = idbmedium
+				remove_country_modifier = idblow
+				clr_country_flag = idbhigh
+				clr_country_flag = idbmedium
+				clr_country_flag = idblow
 			}
+		}
+		ai_will_do = {
+			factor = 100
+		}
 	}
 
-idbhigh = {
+	idbhigh = {
 		picture = "jointheidb"
 
 		potential = {
 			has_country_modifier = idb_chairmanship
 			NOT = { OR = { has_country_modifier = idbhigh_gp
-			has_country_modifier = idbmedium_gp
-			has_country_modifier = idblow_gp } }
-			}
+					has_country_modifier = idbmedium_gp
+					has_country_modifier = idblow_gp } }
+		}
 		allow = {
 			war = no
 			NOT = { AND = { has_country_modifier = idbhigh_gp
-			has_country_modifier = idbmedium_gp
-			has_country_modifier = idblow_gp } }
-	OR = { ai = no AND = { ai = yes economic_policy = state_capitalism } AND = { ai = yes economic_policy = planned_economy } }
-				}
+					has_country_modifier = idbmedium_gp
+					has_country_modifier = idblow_gp } }
+			OR = { ai = no AND = { ai = yes economic_policy = state_capitalism } AND = { ai = yes economic_policy = planned_economy } }
+		}
 		effect = {
-add_country_modifier = { name = idbhigh_gp duration = -1 }
-any_country = { limit = { has_country_modifier = idb_member } add_country_modifier = { name = idbhigh duration = -1 } }
+			add_country_modifier = { name = idbhigh_gp duration = -1 }
+			any_country = { limit = { has_country_modifier = idb_member } add_country_modifier = { name = idbhigh duration = -1 } }
 
-any_country = { limit = { has_country_modifier = idb_member OR = { is_greater_power = no is_secondary_power = no } } relation = { who = THIS value = 50 } }
+			any_country = { limit = { has_country_modifier = idb_member OR = { is_greater_power = no is_secondary_power = no } } relation = { who = THIS value = 50 } }
 			set_global_flag = idbhigh
 		}
-		ai_will_do = { 
-			factor = 1 
-			}
+		ai_will_do = {
+			factor = 1
+		}
 	}
-idbmedium = {
+	idbmedium = {
 		picture = "jointheidb"
 
 		potential = {
 			has_country_modifier = idb_chairmanship
 			NOT = { OR = { has_country_modifier = idbhigh_gp
-			has_country_modifier = idbmedium_gp
-			has_country_modifier = idblow_gp } }
-			}
+					has_country_modifier = idbmedium_gp
+					has_country_modifier = idblow_gp } }
+		}
 		allow = {
 			war = no
 			NOT = { AND = { has_country_modifier = idbhigh_gp
-			has_country_modifier = idbmedium_gp
-			has_country_modifier = idblow_gp } }
-OR = { ai = no AND = { ai = yes economic_policy = interventionism } }
-				}
+					has_country_modifier = idbmedium_gp
+					has_country_modifier = idblow_gp } }
+			OR = { ai = no AND = { ai = yes economic_policy = interventionism } }
+		}
 		effect = {
-add_country_modifier = { name = idbmedium_gp duration = -1 }
-any_country = { limit = { has_country_modifier = idb_member } add_country_modifier = { name = idbmedium duration = -1 } }
+			add_country_modifier = { name = idbmedium_gp duration = -1 }
+			any_country = { limit = { has_country_modifier = idb_member } add_country_modifier = { name = idbmedium duration = -1 } }
 			set_global_flag = idbmedium
 		}
-		ai_will_do = { 
-			factor = 1 
-			}
+		ai_will_do = {
+			factor = 1
+		}
 	}
-idblow = {
+	idblow = {
 		picture = "jointheidb"
 
 		potential = {
 			has_country_modifier = idb_chairmanship
 			NOT = { OR = { has_country_modifier = idbhigh_gp
-			has_country_modifier = idbmedium_gp
-			has_country_modifier = idblow_gp } }
-			}
+					has_country_modifier = idbmedium_gp
+					has_country_modifier = idblow_gp } }
+		}
 		allow = {
 			war = no
 			NOT = { AND = { has_country_modifier = idbhigh_gp
-			has_country_modifier = idbmedium_gp
-			has_country_modifier = idblow_gp } }
-OR = { ai = no AND = { ai = yes economic_policy = laissez_faire } }
+					has_country_modifier = idbmedium_gp
+					has_country_modifier = idblow_gp } }
+			OR = { ai = no AND = { ai = yes economic_policy = laissez_faire } }
 
-				}
+		}
 		effect = {
-add_country_modifier = { name = idblow_gp duration = -1 }
-any_country = { limit = { has_country_modifier = idb_member } add_country_modifier = { name = idblow duration = -1 } }
+			add_country_modifier = { name = idblow_gp duration = -1 }
+			any_country = { limit = { has_country_modifier = idb_member } add_country_modifier = { name = idblow duration = -1 } }
 
-any_country = { limit = { has_country_modifier = idb_member OR = { is_greater_power = no is_secondary_power = no } } relation = { who = THIS value = -50 } }
+			any_country = { limit = { has_country_modifier = idb_member OR = { is_greater_power = no is_secondary_power = no } } relation = { who = THIS value = -50 } }
 			set_global_flag = idblow
 		}
-		ai_will_do = { 
-			factor = 1 
-			}
+		ai_will_do = {
+			factor = 1
+		}
 	}
 
 

--- a/CWE/decisions/Non Proliferation Treaty.txt
+++ b/CWE/decisions/Non Proliferation Treaty.txt
@@ -1,53 +1,56 @@
 political_decisions = {
 
-        non_proliferation_treaty = {
-				picture = "non_proliferation_treaty"
-                potential = {
-					year = 1968
-NOT = { has_country_modifier = atomic_nation }
-NOT = { has_country_modifier = hydrogen_nation }
-NOT = { has_country_modifier = develop_atomic_bomb }
-NOT = { has_country_modifier = develop_hydrogen_bomb }
-NOT = { has_country_modifier = non_proliferation_treaty } 
-					OR = { 
-				badboy = 15
+	non_proliferation_treaty = {
+		picture = "non_proliferation_treaty"
+		potential = {
+			year = 1968
+			NOT = { has_country_modifier = atomic_nation }
+			NOT = { has_country_modifier = hydrogen_nation }
+			NOT = { has_country_modifier = develop_atomic_bomb }
+			NOT = { has_country_modifier = develop_hydrogen_bomb }
+			NOT = { has_country_modifier = non_proliferation_treaty }
+			OR = {
+				badboy = 0.6 NOT = { badboy = 1 }
 				is_vassal = yes
 
-NOT = { any_neighbor_country = { OR = { has_country_modifier = atomic_nation has_country_modifier = hydrogen_nation } badboy = 15 NOT = { relation = { who = THIS value = -190 } } } }
+				NOT = { any_neighbor_country = { OR = { has_country_modifier = atomic_nation has_country_modifier = hydrogen_nation } badboy = 15 NOT = { relation = { who = THIS value = -190 } } } }
 
-is_secondary_power = no 
+				is_secondary_power = no
 
-						AND = { has_country_modifier = alliance_nato OR = { USA = { has_country_modifier = atomic_nation } USA = { has_country_modifier = hydrogen_nation } } }
-						AND = { has_country_modifier = rio_pact OR = { USA = { has_country_modifier = atomic_nation } USA = { has_country_modifier = hydrogen_nation } } }
-						AND = { has_country_modifier = warsaw_pact OR = { RUS = { has_country_modifier = atomic_nation } RUS = { has_country_modifier = hydrogen_nation } } }
-						AND = { has_country_modifier = csto_alliance OR = { RUS = { has_country_modifier = atomic_nation } RUS = { has_country_modifier = hydrogen_nation } } }
-						AND = { has_country_modifier = anzus_alliance OR = { USA = { has_country_modifier = atomic_nation } USA = { has_country_modifier = hydrogen_nation } } }
-						AND = { has_country_modifier = sco_pact OR = { CHI = { has_country_modifier = atomic_nation } CHI = { has_country_modifier = hydrogen_nation } } }
-					}
-                }
+				AND = { has_country_modifier = alliance_nato OR = { USA = { has_country_modifier = atomic_nation } USA = { has_country_modifier = hydrogen_nation } } }
+				AND = { has_country_modifier = rio_pact OR = { USA = { has_country_modifier = atomic_nation } USA = { has_country_modifier = hydrogen_nation } } }
+				AND = { has_country_modifier = warsaw_pact OR = { RUS = { has_country_modifier = atomic_nation } RUS = { has_country_modifier = hydrogen_nation } } }
+				AND = { has_country_modifier = csto_alliance OR = { RUS = { has_country_modifier = atomic_nation } RUS = { has_country_modifier = hydrogen_nation } } }
+				AND = { has_country_modifier = anzus_alliance OR = { USA = { has_country_modifier = atomic_nation } USA = { has_country_modifier = hydrogen_nation } } }
+				AND = { has_country_modifier = sco_pact OR = { CHI = { has_country_modifier = atomic_nation } CHI = { has_country_modifier = hydrogen_nation } } }
+			}
+		}
 
-                allow = {
-					cold_war = 1
-NOT = { 
-OR = { 
-AND = { tag = FRA is_greater_power = yes ai = yes } 
-AND = { tag = ENG is_greater_power = yes ai = yes } 
-AND = { tag = HND is_greater_power = yes ai = yes } 
-AND = { tag = PAK is_greater_power = yes ai = yes } 
-AND = { tag = NKO is_greater_power = yes ai = yes } 
-AND = { tag = CHI is_greater_power = yes ai = yes } 
-AND = { tag = RUS is_greater_power = yes ai = yes } 
-} 
+		allow = {
+			cold_war = 1
+		}
+
+		effect = {
+			add_country_modifier = {
+				name = non_proliferation_treaty
+				duration = 3650
+			}
+		}
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				is_greater_power = yes
+				OR = {
+					tag = FRA
+					tag = ENG
+					tag = HND
+					tag = PAK
+					tag = NKO
+					tag = CHI
+					tag = RUS
+				}
+			}
+		}
+	}
 }
-                }
-
-                effect = {
-					add_country_modifier = {
-                        name = non_proliferation_treaty
-						duration = 3650
-	                }
-                }
-				ai_will_do = { factor = 1 }
-        }
-}		
-        

--- a/CWE/decisions/Organisation for Islamic Cooperation.txt
+++ b/CWE/decisions/Organisation for Islamic Cooperation.txt
@@ -3,18 +3,26 @@ political_decisions = {
 	jointheoic = {
 		picture = "jointheoic"
 		potential = {
-			OR = { pop_majority_religion = sunni pop_majority_religion = ibad pop_majority_religion = shiite has_country_flag = muslim }
-
-			OR = { has_country_flag = muslim NOT = { religious_policy = pro_atheism } } 			
-
-
-NOT = { has_country_modifier = oic_member }
+			OR = { pop_majority_religion = sunni pop_majority_religion = ibad pop_majority_religion = shiite has_country_flag = muslim } # flag from political_events.txt desecularization
+			NOT = { religious_policy = pro_atheism }
+			NOT = { has_country_modifier = oic_member }
 			year = 1969
+			OR = {
+				NOT = { badboy = 1 }
+				AND = {
+					part_of_sphere = yes
+					sphere_owner = { has_country_modifier = oic_chairmanship }
+				}
+				AND = {
+					is_vassal = yes
+					overlord = { has_country_modifier = oic_chairmanship }
+				}
+			}
+			NOT = { is_vassal = yes overlord = { religious_policy = moralism NOT = { has_country_flag = muslim } } } # not vassal of a non-muslim moralist state
 		}
 		allow = {
 			war = no
 			election = no
-NOT = { religious_policy = pro_atheism }
 		}
 		effect = {
 			prestige = 10
@@ -29,7 +37,6 @@ NOT = { religious_policy = pro_atheism }
 		potential = {
 			OR = {
 				religious_policy = pro_atheism
-				AND = { religious_policy = pro_atheism NOT = { has_country_flag = muslim } }
 				NOT = { OR = { pop_majority_religion = sunni pop_majority_religion = ibad pop_majority_religion = shiite has_country_flag = muslim } }
 			}
 			has_country_modifier = oic_member

--- a/CWE/decisions/UNCLOS.txt
+++ b/CWE/decisions/UNCLOS.txt
@@ -1,182 +1,183 @@
 political_decisions = {
 
-join_isa = {
+	join_isa = {
 		picture = "isa"
 		potential = {
-	is_vassal = no
-num_of_ports = 1
-contemporary_agriculture = 1
-year = 1994
-	NOT = { has_country_modifier = isa_member }
-						}
+			is_vassal = no
+			num_of_ports = 1
+			contemporary_agriculture = 1
+			year = 1994
+			NOT = { has_country_modifier = isa_member }
+		}
 		allow = {
 			war = no
 			election = no
-		money = 1000000
-				}
-	effect = {
-prestige = 5
-money = -500000
-add_country_modifier = { name = isa_member duration = -1 }
-}
+			money = 1000000
+		}
+		effect = {
+			prestige = 5
+			money = -500000
+			add_country_modifier = { name = isa_member duration = -1 }
+		}
 		ai_will_do = { 
 			factor = 100 
-			}
+		}
 	}
 
-unclos_1 = {
+	unclos_1 = {
 		picture = "unclos_1"
 		potential = {
-num_of_ports = 1
-has_global_flag = unclos_1
-	NOT = { has_country_flag = unclos_1 }
-						}
+			num_of_ports = 1
+			has_global_flag = unclos_1
+			NOT = { has_country_flag = unclos_1 }
+			has_country_modifier = united_nations
+		}
 		allow = {
 			war = no
-			is_vassal = no
 			election = no
-				}
-	effect = {
-prestige = 5
-set_country_flag = unclos_1
-}
+		}
+		effect = {
+			prestige = 5
+			set_country_flag = unclos_1
+		}
 		ai_will_do = { 
 			factor = 100 
-			}
+		}
 	}
 
-unclos_3 = {
+	unclos_3 = {
 		picture = "unclos_3"
 		potential = {
-num_of_ports = 1
-has_global_flag = unclos_3
-	NOT = { has_country_flag = unclos_3 }
-						}
+			has_country_flag = unclos_1
+			num_of_ports = 1
+			has_global_flag = unclos_3
+			NOT = { has_country_flag = unclos_3 }
+		}
 		allow = {
 			war = no
 			is_vassal = no
 			election = no
-				}
-	effect = {
-prestige = 5
-set_country_flag = unclos_3
-}
+		}
+		effect = {
+			prestige = 5
+			set_country_flag = unclos_3
+		}
 		ai_will_do = { 
 			factor = 100 
-			}
+		}
 	}
 
-claim_12 = {
+	claim_12 = {
 		picture = "claim_12"
 		potential = {
-num_of_ports = 1
-has_country_flag = unclos_1
-NOT = { has_country_flag = claim_24 }
-NOT = { has_country_flag = claim_200 }
-NOT = { has_country_flag = claim_12 }
-						}
+			num_of_ports = 1
+			has_country_flag = unclos_1
+			NOT = { has_country_flag = claim_24 }
+			NOT = { has_country_flag = claim_200 }
+			NOT = { has_country_flag = claim_12 }
+		}
 		allow = {
 			war = no
 			is_vassal = no
 			election = no
-				}
-	effect = {
-prestige = 5
-add_country_modifier = { name = claim_12 duration = -1 }
-set_country_flag = claim_12
-}
+		}
+		effect = {
+			prestige = 5
+			add_country_modifier = { name = claim_12 duration = -1 }
+			set_country_flag = claim_12
+		}
 		ai_will_do = { 
 			factor = 100 
-			}
+		}
 	}
 
-claim_24 = {
+	claim_24 = {
 		picture = "claim_24"
 		potential = {
-num_of_ports = 1
-has_global_flag = unclos_2
-NOT = { has_country_flag = claim_200 }
-has_country_flag = claim_12
-	NOT = { has_country_flag = claim_24 }
-						}
+			num_of_ports = 1
+			has_global_flag = unclos_2
+			NOT = { has_country_flag = claim_200 }
+			has_country_flag = claim_12
+			NOT = { has_country_flag = claim_24 }
+		}
 		allow = {
 			war = no
 			is_vassal = no
 			election = no
-				}
-	effect = {
-prestige = 10
-remove_country_modifier = claim_12
-add_country_modifier = { name = claim_24 duration = -1 }
-set_country_flag = claim_24
-}
+		}
+		effect = {
+			prestige = 10
+			remove_country_modifier = claim_12
+			add_country_modifier = { name = claim_24 duration = -1 }
+			set_country_flag = claim_24
+		}
 		ai_will_do = { 
 			factor = 100 
-			}
+		}
 	}
 
-claim_200 = {
+	claim_200 = {
 		picture = "claim_200"
 		potential = {
-num_of_ports = 1
-has_country_flag = unclos_3
-	NOT = { has_country_flag = claim_200 }
-						}
+			num_of_ports = 1
+			has_country_flag = unclos_3
+			NOT = { has_country_flag = claim_200 }
+		}
 		allow = {
 			war = no
 			is_vassal = no
 			election = no
-				}
-	effect = {
-prestige = 10
-remove_country_modifier = claim_24
-add_country_modifier = { name = claim_200 duration = -1 }
-set_country_flag = claim_200
-}
+		}
+		effect = {
+			prestige = 10
+			remove_country_modifier = claim_24
+			add_country_modifier = { name = claim_200 duration = -1 }
+			set_country_flag = claim_200
+		}
 		ai_will_do = { 
 			factor = 100 
-			}
+		}
 	}
 
-dispute_sea = {
+	dispute_sea = {
 		picture = "dispute_sea"
 		potential = {
-num_of_ports = 1
-has_country_flag = international_court_of_justice
-NOT = { has_country_modifier = sea_dispute }
-OR = { has_country_modifier = claim_200 has_country_modifier = claim_12 has_country_modifier = claim_24 }
-any_neighbor_country = { is_vassal = no num_of_ports = 1 OR = { has_country_modifier = claim_200 has_country_modifier = claim_12 has_country_modifier = claim_24 } 
-NOT = { relation = { who = THIS value = -50 } } }
-						}
-alert = no
+			num_of_ports = 1
+			has_country_flag = international_court_of_justice
+			NOT = { has_country_modifier = sea_dispute }
+			OR = { has_country_modifier = claim_200 has_country_modifier = claim_12 has_country_modifier = claim_24 }
+			any_neighbor_country = { is_vassal = no num_of_ports = 1 OR = { has_country_modifier = claim_200 has_country_modifier = claim_12 has_country_modifier = claim_24 } 
+				NOT = { relation = { who = THIS value = -50 } } }
+		}
+		alert = no
 		allow = {
 			war = no
 			is_vassal = no
 			election = no
-				}
-	effect = {
-add_country_modifier = { name = sea_dispute duration = 1825 }
+		}
+		effect = {
+			add_country_modifier = { name = sea_dispute duration = 1825 }
 
-set_country_flag = sea_dispute_underway
-badboy = 1
+			set_country_flag = sea_dispute_underway
+			badboy = 1
 
-random_country = { 
-limit = { 
+			random_country = { 
+				limit = { 
 
-any_country = { limit = { neighbour = THIS is_vassal = no num_of_ports = 1 
-NOT = { relation = { who = THIS value = -50 } }
-OR = { has_country_modifier = claim_200 has_country_modifier = claim_12 has_country_modifier = claim_24 } }
+					any_country = { limit = { neighbour = THIS is_vassal = no num_of_ports = 1 
+							NOT = { relation = { who = THIS value = -50 } }
+							OR = { has_country_modifier = claim_200 has_country_modifier = claim_12 has_country_modifier = claim_24 } }
 
-NOT = { relation = { who = THIS value = -50 } } 
+						NOT = { relation = { who = THIS value = -50 } } 
 
-}
-	}  
+					}
+				}  
 			}
 
-}
+		}
 		ai_will_do = { 
 			factor = 100 
-			}
+		}
 	}
 
 }


### PR DESCRIPTION
As mentioned in #41, states which are over the infamy limit are still allowed full participation in international orgs. This was changed for several international organizations. Some bugs in the affected decisions were also fixed, such as not being able to request a loan from a sphere owner, market communists not being able to join organization which they are members of, being able to ratify certain UN treaties without being part of the UN, etc.

The UN itself will hopefully be redone with a similar infamy limit and other changes as mentioned in #211.