### PR TITLE
Merge neutrality modifiers

### DIFF
--- a/CWE/common/event_modifiers.txt
+++ b/CWE/common/event_modifiers.txt
@@ -114,13 +114,6 @@ supply_consumption = -0.40
 icon = 15
 }
 
-### Diplomatic Neutrality ###
-
-declared_neutrality = {
-diplomatic_points_modifier = -0.1
-icon = 5
-}
-
 ### World Economic Forum ###
 
 wef_1 = {

--- a/CWE/common/triggered_modifiers.txt
+++ b/CWE/common/triggered_modifiers.txt
@@ -5,6 +5,15 @@
 
 #######
 
+### Diplomatic Neutrality ###
+
+declared_neutrality = {
+	trigger = {
+		has_country_flag = neutrality
+	}
+	diplomatic_points_modifier = -0.1
+}
+
 isolated_nation = {
 
 	trigger = {

--- a/CWE/decisions/Neutrality.txt
+++ b/CWE/decisions/Neutrality.txt
@@ -1,60 +1,69 @@
 political_decisions = {
 
-declare_neutrality = {
+	declare_neutrality = {
 		picture = "declare_neutrality"
-	potential = {
-NOT = { has_country_modifier = declared_neutrality }
-is_vassal = no
-is_greater_power = no
-is_secondary_power = no
+		potential = {
+			NOT = { has_country_flag = neutrality }
+			is_vassal = no
+			is_greater_power = no
+			is_secondary_power = no
 		}
-alert = no
-	allow = {
-NOT = { badboy = 0.5 }
-NOT = { war_policy = jingoism }
-war = no
-OR = { 
-government = sar_government
-AND = { tag = SWI government = democracy ai = yes }
-AND = { tag = AUS government = democracy ai = yes }
-AND = { pop_majority_ideology = progressive ruling_party_ideology = progressive }
-
-AND = { war_policy = pacifism ai = no }
-}
-					}
-		effect = {
-prestige = -50
-add_country_modifier = { name = declared_neutrality duration = -1 }
-any_country = { limit = { alliance_with = THIS } leave_alliance = THIS }
-set_country_flag = renounced_war_rights
-		}
-		ai_will_do = { 
-			factor = 1
+		alert = no
+		allow = {
+			NOT = { badboy = 0.5 }
+			NOT = { war_policy = jingoism }
+			war = no
+			OR = { 
+				government = sar_government
+				AND = { pop_majority_ideology = progressive ruling_party_ideology = progressive }
+				AND = { war_policy = pacifism ai = no }
 			}
+		}
+		effect = {
+			prestige = -50
+			set_country_flag = neutrality
+			any_country = { limit = { alliance_with = THIS } leave_alliance = THIS }
+			set_country_flag = renounced_war_rights
+		}
+		ai_will_do = {
+			factor = 1
+		}
 	}
 
-renounce_neutrality = {
+	renounce_neutrality = {
 		picture = "renounce_neutrality"
-	potential = {
-has_country_modifier = declared_neutrality
-NOT = { AND = { tag = SWI government = democracy ai = yes } }
-NOT = { AND = { tag = AUS government = democracy ai = yes } }
+		potential = {
+			has_country_flag = neutrality
+			is_vassal = no
+			NOT = { government = sar_government }
 		}
-alert = no
-	allow = {
-war = no
-is_vassal = no
-NOT = { government = sar_government }
-OR = { is_greater_power = yes is_secondary_power = yes war_policy = jingoism }
-					}
+		alert = no
+		allow = {
+			war = no
+			OR = { is_greater_power = yes is_secondary_power = yes war_policy = jingoism }
+		}
 		effect = {
-prestige = -50
-add_country_modifier = { name = declared_neutrality duration = -1 }
-set_country_flag = renounced_war_rights
+			prestige = -50
+			remove_country_modifier = declared_neutrality
+			clr_country_flag = renounced_war_rights
 		}
 		ai_will_do = { 
 			factor = 1
+			modifier = {
+				factor = 0
+				tag = SWI
+				government = democracy
 			}
+			modifier = {
+				factor = 0
+				tag = AUS
+				government = democracy
+			}
+			modifier = {
+				factor = 0
+				ruling_party_ideology = progressive
+			}
+		}
 	}
 
 }

--- a/CWE/events/Essential Events 6.txt
+++ b/CWE/events/Essential Events 6.txt
@@ -575,24 +575,23 @@ any_country = { limit = { NOT = { OR = { government = proletarian_dictatorship g
 #Protect Neutral Countries
 country_event = {
 	id = 1412143
-title = "Diplomatic neutrality violated"
+	title = "Diplomatic neutrality violated"
 	desc = "Neutral $COUNTRY$'s diplomatic immunity has been violated. All nations at war with $COUNTRY$ will be punished by the international community."
 	picture = "arctic_r_lose"
 	major = yes
 
-trigger = { 
-any_neighbor_country = { war_with = THIS }
-war = yes
-NOT = { has_country_flag = declared_neutrality_active }
-has_country_modifier = declared_neutrality
-}
+	trigger = {
+		any_neighbor_country = { war_with = THIS }
+		war = yes
+		NOT = { has_country_flag = declared_neutrality_active }
+		has_country_flag = neutrality
+	}
 
-option = {
-name = "We need their support"
-set_country_flag = declared_neutrality_active
-any_country = { limit = { war_with = THIS } country_event = 1412144 }
-
-any_country = { limit = { has_country_modifier = united_nations_ga_member exists = yes NOT = { war_with = THIS } } create_alliance = THIS relation = { who = THIS value = 50 } }
-		}
+	option = {
+		name = "We need their support"
+		set_country_flag = declared_neutrality_active
+		any_country = { limit = { war_with = THIS } country_event = 1412144 }
+		any_country = { limit = { has_country_modifier = united_nations_ga_member exists = yes NOT = { war_with = THIS } } create_alliance = THIS relation = { who = THIS value = 50 } }
+	}
 
 }

--- a/CWE/events/Essential Events 7.txt
+++ b/CWE/events/Essential Events 7.txt
@@ -1,22 +1,22 @@
 #Protect Neutral Countries
 country_event = {
 	id = 1412145
-title = "Diplomatic neutrality restored"
+	title = "Diplomatic neutrality restored"
 	desc = "Peace has returned to our country. The international community celebrates the return to the rule of law."
 	picture = "neutrality_violated"
 
-trigger = { 
-war = no
-has_country_flag = declared_neutrality_active
-has_country_modifier = declared_neutrality
-}
+	trigger = { 
+		war = no
+		has_country_flag = declared_neutrality_active
+		has_country_flag = neutrality
+	}
 
-option = {
-name = "We thank the international community for their support"
-prestige = 10
-clr_country_flag = declared_neutrality_active
-any_country = { limit = { alliance_with = THIS } leave_alliance = THIS }
-		}
+	option = {
+		name = "We thank the international community for their support"
+		prestige = 10
+		clr_country_flag = declared_neutrality_active
+		any_country = { limit = { alliance_with = THIS } leave_alliance = THIS }
+	}
 }
 
 #Indo-Pakistan Conflict

--- a/CWE/history/countries/SWI - Switzerland.txt
+++ b/CWE/history/countries/SWI - Switzerland.txt
@@ -9,7 +9,7 @@ nationalvalue = nv_equality
 literacy = 0.11
 non_state_culture_literacy = 0.0
 civilized = yes
-prestige = 750
+prestige = 800
 last_election = 1944.7.1
 ruling_party = party_conservative_0_SWI
 upper_house = {
@@ -75,6 +75,7 @@ consciousness = 1
 nonstate_consciousness = 1
 schools = commerce_tech_school
 oob = "/SWI_oob.txt"
+decision = declare_neutrality
 
 1992.1.1 = {
 	capital = 605


### PR DESCRIPTION
Merge the two different neutrality conditions, fix a big where renouncing neutrality was impossible, set SWI as neutral immediately.  
Merging the decisions will make it such that countries which declare neutrality can no longer join blocs, and similar changes.

This is a prerequisite to #161, as those events seem to have their own flag for neutrality which can easily be replaced with this one, and to allow a non-neutral Austria.