### PR TITLE
Greater Finland unclaimed cores

### DIFF
--- a/CWE/decisions/claim_greater.txt
+++ b/CWE/decisions/claim_greater.txt
@@ -1114,7 +1114,6 @@ political_decisions = {
                 allow = {
                        tag = FIN
 						part_of_sphere = no
-						has_unclaimed_cores = no
 						NOT = {	
 							has_country_flag = claim_greater_finland
 							ruling_party_ideology = socialist


### PR DESCRIPTION
Removed the unclaimed cores condition for greater Finland as this was not possible due to Åland controlling their islands.