### PR TITLE
Fix Finnish-Soviet War

### DIFF
--- a/CWE/decisions/Neutrality.txt
+++ b/CWE/decisions/Neutrality.txt
@@ -7,11 +7,11 @@ political_decisions = {
 			NOT = { has_country_flag = neutrality }
 			is_vassal = no
 			is_greater_power = no
-			is_secondary_power = no
+			is_secondary_power = no			
 		}
 		alert = no
-		allow = {
-			NOT = { badboy = 0.5 }
+		allow = {		
+			NOT = { badboy = 0.5 } 
 			NOT = { war_policy = jingoism }
 			war = no
 			OR = { 
@@ -27,6 +27,7 @@ AND = { tag = COS government = democracy }
 AND = { tag = FIN government = democracy }
 AND = { tag = MAL government = democracy }
 AND = { tag = SWE government = hms_government }
+AND = { tag = FIN has_country_flag = finnish_question }
 
 			}
 		}

--- a/CWE/events/finland.txt
+++ b/CWE/events/finland.txt
@@ -128,7 +128,8 @@ country_event = {
     name = EVT_8005526_A
 	diplomatic_influence = { who = FIN value = 200 }
 	FIN = { country_event = 8005527 }
-	ai_chance = { factor = 0.1 }
+	ai_chance = { factor = 0.6 }
+	FIN = { set_country_flag = finnish_question }
   }
 
   option = {
@@ -142,7 +143,7 @@ country_event = {
 	}
 	badboy = 10
 	money = -500
-	ai_chance = { factor = 0.9 }
+	ai_chance = { factor = 0.4 }
   }
 }
 country_event = {


### PR DESCRIPTION
Currently the Soviet AI has a 90% chance of picking the option to invade Finland to establish a puppet state, given that this did not happen historically, the chance has been lowered to 40%. On top of that, Finland has a 100% chance of declaring international neutrality leading to 100 infamy and a UN coalition against the soviets, on top of the 10 infamy provided by the event. This patch therefore also prevents Finland from declaring neutrality until the invasion event fires and Soviets pick not to invade.
