### PR TITLE
Changes to Free Territory of Trieste

### DIFF
--- a/CWE/events/Essential Events 8.txt
+++ b/CWE/events/Essential Events 8.txt
@@ -6682,6 +6682,7 @@ option = {
 name = "Sign the treaty"
 prestige = 50
 736 = { remove_core = YUG }
+3345 = { remove_core = YUG } #in case Italy also owns Koper
 relation = { who = ITA value = 100 }
 ai_chance = { factor = 0.8 }
 		}

--- a/CWE/events/trieste.txt
+++ b/CWE/events/trieste.txt
@@ -17,6 +17,7 @@ country_event = {
 
   option = {
     name = EVT_8020300_A
+	YUG = { country_event = 8020301 }
 	release_vassal = TRE 
 	TRE = { government = sar_government }
 	badboy = -5 
@@ -34,10 +35,38 @@ country_event = {
 	ai_chance = { factor = 0 }
   }
 }
+
 country_event = {
   id = 8020301
-  title = EVT_8020301_NAME
+  title = EVT_802031_NAME
   desc = EVT_8020301_DESC
+  picture = "nwo2_free_city_of_trieste"
+  
+  is_triggered_only = yes #YUG
+
+  option = {
+    name = EVT_8020301_A
+	3345 = { secede_province = TRE } 
+	relation = { who = USA value = 50 } 
+	relation = { who = ITA value = 25 } 
+	ai_chance = { factor = 0.9 }
+  }
+  
+    option = {
+    name = EVT_8020301_B
+	any_pop = { militancy = 0.3  consciousness = 1.0 }
+	badboy = 5
+	relation = { who = USA value = -100 } 
+	relation = { who = ITA value = -50 } 
+	USA = { casus_belli = { target = YUG type = free_allied_cores months = 24 }}
+	ai_chance = { factor = 0.1 }
+  }
+}
+
+country_event = {
+  id = 8020302
+  title = EVT_8020302_NAME
+  desc = EVT_8020302_DESC
   picture = "nwo2_free_city_of_trieste"
   fire_only_once = yes
 
@@ -69,8 +98,8 @@ country_event = {
   mean_time_to_happen = { months = 9 }
 
   option = {
-	name = EVT_8020301_A
-	USA = { country_event = 8020302 } 
+	name = EVT_8020302_A
+	USA = { country_event = 8020303 } 
 	badboy = -5 
 	relation = { who = ITA value = 100 } 
 	relation = { who = USA value = 25 } 
@@ -100,8 +129,8 @@ country_event = {
   }
 
   option = {
-	name = EVT_8020301_B
-	USA = { country_event = 8020303 }
+	name = EVT_8020302_B
+	USA = { country_event = 8020304 }
 	any_pop = { militancy = 0.3  consciousness = 1.0 }
 	badboy = 5 
 	relation = { who = ITA value = -150 } 
@@ -121,29 +150,7 @@ country_event = {
 	}
   }
 }
-country_event = {
-  id = 8020302
-  title = EVT_8020302_NAME
-  desc = EVT_8020302_DESC
-  picture = "nwo2_free_city_of_trieste"
 
-  is_triggered_only = yes # USA
-
-  option = {
-    name = EVT_8020302_A
-	ITA = { country_event = 8020305 }
-	relation = { who = ITA value = 100 } 
-	any_pop = { militancy = -0.2  consciousness = -0.1 }
-	ai_chance = { factor = 1 }
-  }
-  option = {
-    name = EVT_8020302_B
-	relation = { who = ITA value = -100 } 
-	any_pop = { militancy = 0.2  consciousness = 1.0 }
-	ai_chance = { factor = 0 }
-  }
-  
-}
 country_event = {
   id = 8020303
   title = EVT_8020303_NAME
@@ -154,6 +161,34 @@ country_event = {
 
   option = {
     name = EVT_8020303_A
+	3345 = { secede_province = YUG }
+	ITA = { country_event = 8020306 }
+	relation = { who = ITA value = 100 }
+	any_pop = { militancy = -0.2  consciousness = -0.1 }
+	ai_chance = { factor = 0.8 }
+  }
+  option = {
+    name = EVT_8020303_B
+	relation = { who = ITA value = -100 } 
+	any_pop = { militancy = 0.2  consciousness = 1.0 }
+	ai_chance = { factor = 0 }
+  }
+  option = {
+	name = EVT_8020303_C
+	YUG = { country_event = 8020307 }
+	ai_chance = { factor = 0.2 }
+}
+
+country_event = {
+  id = 8020304
+  title = EVT_8020304_NAME
+  desc = EVT_8020304_DESC
+  picture = "nwo2_free_city_of_trieste"
+
+  is_triggered_only = yes # USA
+
+  option = {
+    name = EVT_8020304_A
 	any_pop = { militancy = 0.3  consciousness = 1.0 }
 	ai_chance = {
 		factor = 0.5
@@ -166,8 +201,8 @@ country_event = {
   }
 
   option = {
-	name = EVT_8020303_B
-	FROM = { country_event = 8020304 }
+	name = EVT_8020304_B
+	FROM = { country_event = 8020305 }
 	any_pop = { militancy = 0.5  consciousness = 0.5 }
 	relation = { who = FROM value = 100 } 
 	relation = { who = ITA value = -100 } 
@@ -205,16 +240,17 @@ country_event = {
 	}
   }
 }
+
 country_event = {
-  id = 8020304
-  title = EVT_8020304_NAME
-  desc = EVT_8020304_DESC
+  id = 8020305
+  title = EVT_8020305_NAME
+  desc = EVT_8020305_DESC
   picture = "nwo2_free_city_of_trieste"
 
   is_triggered_only = yes # YUG
 
   option = {
-    name = EVT_8020304_A
+    name = EVT_8020305_A
 	inherit = TRE
 	prestige = 10
 	any_country = {
@@ -229,16 +265,57 @@ country_event = {
 }
 
 country_event = {
-  id = 8020305
-  title = EVT_8020302_NAME
-  desc = EVT_8020302_DESC
+  id = 8020306
+  title = EVT_8020303_NAME
+  desc = EVT_8020303_DESC
   picture = "nwo2_free_city_of_trieste"
 
   is_triggered_only = yes # ITA
 
   option = {
-    name = EVT_8020302_A
+    name = EVT_8020303_A
 	inherit = TRE
 	prestige = 10
+  }
+}
+
+country_event = {
+  id = 8020307
+  title = EVT_8020307_NAME
+  desc = EVT_8020307_DESC
+  picture = "nwo2_free_city_of_trieste"
+
+ is_triggered_only = yes # YUG
+
+  option = {
+    name = EVT_8020307_A
+	relation = { who = USA value = -50 }
+	relation = { who = ITA value = -50 }
+	any_pop = { militancy = -0.2  consciousness = -0.1 }
+	ai_chance = { factor = 0.8 }
+}
+  option = {
+    name = EVT_8020307_B
+	ITA = { country_event = 8020307 }
+	relation = { who = ITA value = 100 }
+	badboy = -2
+	any_pop = { militancy = -0.2  consciousness = -0.1 }
+	ai_chance = { factor = 0.2 }
+}
+
+country_event = {
+  id = 8020307
+  title = EVT_8020303_NAME
+  desc = EVT_8020303_DESC
+  picture = "nwo2_free_city_of_trieste"
+
+  is_triggered_only = yes # ITA
+
+  option = {
+    name = EVT_8020303_A
+	inherit = TRE
+	3345 = add_core = ITA
+	3345 = { change_province_name = "Capodistria" }
+	prestige = 25
   }
 }

--- a/CWE/events/trieste.txt
+++ b/CWE/events/trieste.txt
@@ -290,6 +290,7 @@ country_event = {
 
   option = {
     name = EVT_8020307_A
+	ITA = { country_event = 8020306 }
 	relation = { who = USA value = -50 }
 	relation = { who = ITA value = -50 }
 	any_pop = { militancy = -0.2  consciousness = -0.1 }

--- a/CWE/events/trieste.txt
+++ b/CWE/events/trieste.txt
@@ -177,6 +177,7 @@ country_event = {
 	name = EVT_8020303_C
 	YUG = { country_event = 8020307 }
 	ai_chance = { factor = 0.2 }
+ }
 }
 
 country_event = {
@@ -293,18 +294,19 @@ country_event = {
 	relation = { who = ITA value = -50 }
 	any_pop = { militancy = -0.2  consciousness = -0.1 }
 	ai_chance = { factor = 0.8 }
-}
+  }
   option = {
     name = EVT_8020307_B
-	ITA = { country_event = 8020307 }
+	ITA = { country_event = 8020308 }
 	relation = { who = ITA value = 100 }
 	badboy = -2
 	any_pop = { militancy = -0.2  consciousness = -0.1 }
 	ai_chance = { factor = 0.2 }
+  }
 }
 
 country_event = {
-  id = 8020307
+  id = 8020308
   title = EVT_8020303_NAME
   desc = EVT_8020303_DESC
   picture = "nwo2_free_city_of_trieste"
@@ -314,7 +316,7 @@ country_event = {
   option = {
     name = EVT_8020303_A
 	inherit = TRE
-	3345 = add_core = ITA
+	3345 = { add_core = ITA }
 	3345 = { change_province_name = "Capodistria" }
 	prestige = 25
   }

--- a/CWE/localisation/nwo_events.csv
+++ b/CWE/localisation/nwo_events.csv
@@ -3302,24 +3302,33 @@ EVT_8214020_DESC;British Raj was a jewel in British crown that was becoming more
 EVT_8214020_A;Give them independence;;;;;;;;;;X
 EVT_8214020_B;Remain there anyway;;;;;;;;;;X
 EVT_8020300_NAME;Free Territory of Trieste;;;;;;;;;;X
-EVT_8020300_DESC;"The Free Territory of Trieste was a city-state situated in Central Europe between northern Italy and Yugoslavia, created by the United Nations Security Council in the aftermath of World War II and provisionally administered by an appointed American or British military governor commanding the peacekeeping American and British forces stationed there.;;;;;;;;;;X
-EVT_8020300_A;Allow its formation;;;;;;;;;;X
-EVT_8020300_B;Prevent its formation at all cost;;;;;;;;;;X
-EVT_8020301_NAME;Fate of Free Territory of Trieste;;;;;;;;;;X
-EVT_8020301_DESC;On 5 October 1954, the London Memorandum was signed in the British capital by ministers of the United States, United Kingdom, Italy, and Yugoslavia. It gave former Zone A with Trieste to Italy for an ordinary civil administration, and Zone B, which had already incorporated a communist government since 1947, to Yugoslavia. In addition, Yugoslavia was given several villages in the Muggia municipality that had been part of Zone A: Plavje, Spodnje Škofije, Jelarji, Hrvatini, Kolomban, Cerej, Premanèan and Barizoni. The castle and village of Socerb above San Dorligo della Valle was also ceded to Yugoslavia.;;;;;;;;;;X
-EVT_8020301_A;Let's divide the territory;;;;;;;;;;X
-EVT_8020301_B;We want Trst for ourselves!;;;;;;;;;;X
-EVT_8020302_NAME;Annexation of Free Territory of Trieste;;;;;;;;;;X
+EVT_8020300_DESC;The Free Territory of Trieste was a city-state situated in Central Europe between northern Italy and Yugoslavia, created by the United Nations Security Council in the aftermath of World War II. The territory was divided into two areas: Zone A, comprising the port city of Trieste with a narrow coastal strip to the north west, under British and American administration, and Zone B, formed by Koper and a small portion of the north-western part of the Istrian peninsula.;;;;;;;;;;X
+EVT_8020300_A;Allow its formation.;;;;;;;;;;X
+EVT_8020300_B;Prevent its formation at all cost.;;;;;;;;;;X
+EVT_8020301_NAME;Free Territory of Trieste;;;;;;;;;;X
+EVT_8020301_DESC;The Free Territory of Trieste was a city-state situated in Central Europe between northern Italy and Yugoslavia, created by the United Nations Security Council in the aftermath of World War II. The territory was divided into two areas: Zone A, comprising the port city of Trieste with a narrow coastal strip to the north west, under British and American administration, and Zone B, formed by Koper and a small portion of the north-western part of the Istrian peninsula.;;;;;;;;;;X
+EVT_8020301_A;Allow its formation.;;;;;;;;;;X
+EVT_8020301_B;Keep Koper for ourselves.;;;;;;;;;;X
+EVT_8020302_NAME;Fate of the Free Territory of Trieste;;;;;;;;;;X
 EVT_8020302_DESC;On 5 October 1954, the London Memorandum was signed in the British capital by ministers of the United States, United Kingdom, Italy, and Yugoslavia. It gave former Zone A with Trieste to Italy for an ordinary civil administration, and Zone B, which had already incorporated a communist government since 1947, to Yugoslavia. In addition, Yugoslavia was given several villages in the Muggia municipality that had been part of Zone A: Plavje, Spodnje Škofije, Jelarji, Hrvatini, Kolomban, Cerej, Premanèan and Barizoni. The castle and village of Socerb above San Dorligo della Valle was also ceded to Yugoslavia.;;;;;;;;;;X
-EVT_8020302_A;That's the best outcome;;;;;;;;;;X
-EVT_8020302_B;Keep the status quo;;;;;;;;;;X
-EVT_8020303_NAME;Yugoslavs push the Trieste issue;;;;;;;;;;X
-EVT_8020303_DESC;Even though Yugoslav government was initially ready to solve the Trieste issue and divide the area along the occupation lines, Tito's stance hardened since then and he wants us to leave Trieste and award it to socialist Yugoslavia as a part of war reparations. The Allied troops still station in Trieste so we shouldn't be intimidated too much but still we may make a gesture of kindness to ease tensions between two countries.;;;;;;;;;;X
-EVT_8020303_A;We will stay in Trieste;;;;;;;;;;X
-EVT_8020303_B;We'll transfer the city to Yugoslavia;;;;;;;;;;X
-EVT_8020304_NAME;Trst is ours!;;;;;;;;;;X
-EVT_8020304_DESC;Thanks to good will of Italians and our strong pressure, the city of Trst joins Slovenia to push our boundaries even further west! Acquisition of such an important city will be beneficial for our industry and commerce.;;;;;;;;;;X
-EVT_8020304_A;Great!;;;;;;;;;;X
+EVT_8020302_A;Let's divide the territory.;;;;;;;;;;X
+EVT_8020302_B;We want Trst for ourselves!;;;;;;;;;;X
+EVT_8020303_NAME;Annexation of Free Territory of Trieste;;;;;;;;;;X
+EVT_8020303_DESC;On 5 October 1954, the London Memorandum was signed in the British capital by ministers of the United States, United Kingdom, Italy, and Yugoslavia. It gave former Zone A with Trieste to Italy for an ordinary civil administration, and Zone B, which had already incorporated a communist government since 1947, to Yugoslavia. In addition, Yugoslavia was given several villages in the Muggia municipality that had been part of Zone A: Plavje, Spodnje Škofije, Jelarji, Hrvatini, Kolomban, Cerej, Premanèan and Barizoni. The castle and village of Socerb above San Dorligo della Valle was also ceded to Yugoslavia.;;;;;;;;;;X
+EVT_8020303_A;That's the best outcome.;;;;;;;;;;X
+EVT_8020303_B;Keep the status quo.;;;;;;;;;;X
+EVT_8020303_C;Pressure Yugoslavia to cede Koper too.;;;;;;;;;;X
+EVT_8020304_NAME;Yugoslavs push the Trieste issue;;;;;;;;;;X
+EVT_8020304_DESC;Even though the Yugoslav government was initially ready to solve the Trieste issue and divide the area along the occupation lines, Tito's stance hardened since then, and he wants us to leave Trieste and award it to socialist Yugoslavia as a part of war reparations. Allied troops are still stationed in Trieste so we shouldn't be intimidated too much, but still we may make a gesture of kindness to ease tensions between the two countries.;;;;;;;;;;X
+EVT_8020304_A;We will stay in Trieste.;;;;;;;;;;X
+EVT_8020304_B;We'll transfer the city to Yugoslavia.;;;;;;;;;;X
+EVT_8020305_NAME;Trst is ours!;;;;;;;;;;X
+EVT_8020305_DESC;Thanks to good will of Italians and our strong pressure, the city of Trst joins Slovenia to push our boundaries even further west! Acquisition of such an important city will be beneficial for our industry and commerce.;;;;;;;;;;X
+EVT_8020305_A;Great!;;;;;;;;;;X
+EVT_8020307_NAME;Americans push the Koper issue;;;;;;;;;;X
+EVT_8020307_DESC;Even though the American and Italian governments were initially ready to solve the Trieste issue and divide the area along the occupation lines, the Americans now propose that Italy should get to keep Koper, citing the historical Italian presence there, and stating that the small town, once separated from the larger and more prosperous Trieste on which its economy depended, would fall into a critical decline from which it would never recover. According to the official documents we are legally entitled to keep Koper, and they can't force us to accept their demands. On the other hand they do raise some good points, and accepting would certainly strenghten our relations with Italy and maybe even pave the way for a future partnership.;;;;;;;;;;X
+EVT_8020307_A;Koper is righful Yugoslavian land!;;;;;;;;;;X
+EVT_8020307_B;We'll transfer the city to Italy.;;;;;;;;;;X
 EVT_8020510_NAME;Morning Star flag;;;;;;;;;;X
 EVT_8020510_DESC;"After territorial elections in January 1961 a New Guinea Council consisting of 28 members were sworn into office by Governor Dr. P.J.Platteel on 1 April 1961. An emergency session of this Council on 19 October 1961 in response to news that the Hague was considering transferring the West New Guinea territory first to United Nations and then Indonesian administration;;;;;;;;;;X
 EVT_8020510_A;Raise the new flag;;;;;;;;;;X


### PR DESCRIPTION
Changes to the Free Territory of Trieste event chain following suggestions in #534:

- Yugoslavia will get an event to cede Koper to the Free Territory of Trieste when it forms, as historically it was part of Zone B until 1954;

- The US has an option to ask Yugoslavia to give Koper back to Italy when the Free Territory of Trieste dissolves;

- Edited Treaty of Osimo to include Koper.