### PR TITLE
Italian minority in Lybia + minor tweaks

### DIFF
--- a/CWE/events/trieste.txt
+++ b/CWE/events/trieste.txt
@@ -38,7 +38,7 @@ country_event = {
 
 country_event = {
   id = 8020301
-  title = EVT_802031_NAME
+  title = EVT_8020301_NAME
   desc = EVT_8020301_DESC
   picture = "nwo2_free_city_of_trieste"
   
@@ -165,19 +165,33 @@ country_event = {
 	ITA = { country_event = 8020306 }
 	relation = { who = ITA value = 100 }
 	any_pop = { militancy = -0.2  consciousness = -0.1 }
-	ai_chance = { factor = 0.8 }
-  }
+	ai_chance = { 
+			factor = 0.8
+			modifier = { 
+					factor = 0.5
+					NOT = { relation = { who = ITA value = 50 }}
+			}
+	}
+}
+
   option = {
     name = EVT_8020303_B
 	relation = { who = ITA value = -100 } 
 	any_pop = { militancy = 0.2  consciousness = 1.0 }
 	ai_chance = { factor = 0 }
   }
+  
   option = {
 	name = EVT_8020303_C
 	YUG = { country_event = 8020307 }
-	ai_chance = { factor = 0.2 }
- }
+	ai_chance = {
+			factor = 0.1
+			modifier = { 
+					factor = 2
+					relation = { who = ITA value = 100 }
+			}
+	}
+  }
 }
 
 country_event = {

--- a/CWE/history/pops/1946.1.1/United Kingdom.txt
+++ b/CWE/history/pops/1946.1.1/United Kingdom.txt
@@ -2840,13 +2840,23 @@
 	capitalists = {
 		culture = jewish
 		religion =  jewish 
-		size = 535
+		size = 229
 	 } 
 	capitalists = {
 		culture = libyan
 		religion = secularism
-		size = 16
+		size = 11
 	 } 
+	capitalists = {
+		culture = italian
+		religion = catholic
+		size = 306
+	}
+	capitalists = {
+		culture = italian
+		religion = secularism
+		size = 5
+	} 
 	officers = {
 		culture = jewish
 		religion =  jewish 
@@ -2870,13 +2880,23 @@
 	aristocrats = {
 		culture = jewish
 		religion =  jewish 
-		size = 4287
+		size = 2827
 	 } 
 	aristocrats = {
 		culture = libyan
 		religion = secularism
-		size = 500
-	 } 
+		size = 438
+	 }
+	aristocrats = {
+		culture = italian
+		religion = catholic
+		size = 1462
+	}
+	aristocrats = {
+		culture = italian
+		religion = secularism
+		size = 60
+	} 
 	bureaucrats = {
 		culture = jewish
 		religion =  jewish 
@@ -2900,13 +2920,23 @@
 	artisans = {
 		culture = jewish
 		religion =  jewish 
-		size = 2942
+		size = 2032
 	 } 
 	artisans = {
 		culture = jewish
 		religion = secularism
-		size = 90
-	 } 
+		size = 57
+	 }
+	artisans = {
+		culture = italian
+		religion = catholic
+		size = 910
+	}
+	artisans = {
+		culture = italian
+		religion = secularism
+		size = 33
+	}  
 	farmers = {
 		culture = jewish
 		religion =  jewish 
@@ -2920,9 +2950,19 @@
 	farmers = {
 		culture = berber
 		religion =  sunni 
-		size = 85209
-	 } 
-
+		size = 62546
+	 }
+	farmers = {
+		culture = italian
+		religion = catholic
+		size = 20140
+	}
+	farmers = {
+		culture = italian
+		religion = secularism
+		size = 2523
+	}
+	
 	#For Pan-Arab and National Arab
 	farmers = {
 		culture = libyan
@@ -2964,11 +3004,31 @@
 }
 #Misratah - Misratah (85000/21250 POPS)
 1733 = {
+	capitalists = {
+		culture = italian
+		religion = catholic
+		size = 119
+	}
+	capitalists = {
+		culture = italian
+		religion = secularism
+		size = 58
+	} 
 	farmers = {
 		culture = berber
 		religion =  sunni 
-		size = 16421
+		size = 15621
 	 } 
+	farmers = {
+		culture = italian
+		religion = catholic
+		size = 598
+	}
+	farmers = {
+		culture = italian
+		religion = secularism
+		size = 25
+	} 
 
 	#For Pan-Arab and National Arab
 	farmers = {
@@ -3011,6 +3071,26 @@
 		religion =  sunni 
 		size = 1550
 	 } 
+	aristocrats = {
+		culture = italian
+		religion = catholic
+		size = 1203
+	}
+	aristocrats = {
+		culture = italian
+		religion = secularism
+		size = 17
+	} 
+	capitalists = {
+		culture = italian
+		religion = catholic
+		size = 686
+	}
+	capitalists = {
+		culture = italian
+		religion = secularism
+		size = 43
+	} 
 	artisans = {
 		culture = berber
 		religion =  sunni 
@@ -3019,8 +3099,18 @@
 	farmers = {
 		culture = berber
 		religion =  sunni 
-		size = 29941
+		size = 24941
 	 } 
+	farmers = {
+		culture = italian
+		religion = catholic
+		size = 2890
+	}
+	farmers = {
+		culture = italian
+		religion = secularism
+		size = 161
+	} 
 
 	#For Pan-Arab and National Arab
 	farmers = {


### PR DESCRIPTION
- Added Italian pops in Tripoli, Benghazi and Misratah, as suggested in #534;

- Minor tweaks to Trieste event chain. 