### PR TITLE
Fixes scandinavia not inherting scandinavian countries

### DIFF
--- a/CWE/decisions/Form Scandinavia.txt
+++ b/CWE/decisions/Form Scandinavia.txt
@@ -73,7 +73,7 @@ political_decisions = {
 				limit = {
 					OR = { tag = FIN tag = SWE tag = NOR tag = DEN tag = FAR tag = ICL tag = ALA }
 				}
-				country_event = 11101
+				annex_to = THIS
 			}
 		}
 		ai_will_do = {


### PR DESCRIPTION
See title.

For whatever reason, only Åland gets inherited when using the event, using annex_to everyone does.