### PR TITLE
Apartheid and Balkan Federation fixes

### DIFF
--- a/CWE/common/pop_types.txt
+++ b/CWE/common/pop_types.txt
@@ -921,11 +921,13 @@ assimilation_chance = { # 1
     	factor = -20
 		has_culture_core = yes
 	}
+	
 	modifier = {
 	factor = -20 
 		OR = { is_culture_group = african_diaspora_cultures is_culture_group = african }
 		country = { has_country_modifier = apartheid }
 	}
+	
 	group = {
 		modifier = {
 			factor = 2

--- a/CWE/common/pop_types.txt
+++ b/CWE/common/pop_types.txt
@@ -921,7 +921,11 @@ assimilation_chance = { # 1
     	factor = -20
 		has_culture_core = yes
 	}
-
+	modifier = {
+	factor = -20 
+		OR = { is_culture_group = african_diaspora_cultures is_culture_group = african }
+		country = { has_country_modifier = apartheid }
+	}
 	group = {
 		modifier = {
 			factor = 2

--- a/CWE/decisions/Balkan Federation.txt
+++ b/CWE/decisions/Balkan Federation.txt
@@ -80,7 +80,7 @@ KOS = { OR = { tag = THIS exists = no in_sphere = THIS vassal_of = THIS } }
 		effect = {
 prestige = 50
 change_tag = BKF
-any_country = { limit = { OR = { tag = SER tag = YUG tag = ALB tag = ROM tag = GRE tag = BUL AND = { capital_scope = { continent = europe } in_sphere = THIS } } }
+any_country = { limit = { OR = { tag = SER tag = YUG tag = ALB tag = ROM tag = GRE tag = BUL } }
 country_event = 11101 }
 primary_culture = yugoslav
 add_accepted_culture = serb


### PR DESCRIPTION
With these changes countries with Apartheid no longer canassimilate african cultures, while the Balkan Federation formation only annexes the balkanic countries.