### PR TITLE
Update army_tech.txt

### DIFF
--- a/CWE/technologies/army_tech.txt
+++ b/CWE/technologies/army_tech.txt
@@ -7,7 +7,7 @@ post_war_radar = {
 
 	activate_building = fort	
 	army_base = {
-		supply_consumption = 0.10
+		supply_consumption = 0.05
 	}
 
 	dig_in_cap = 1
@@ -60,7 +60,7 @@ strategic_bomber = {
 	}
 	
 	army_base = {
-		supply_consumption = 0.10
+		supply_consumption = 0.05
 	}
 
 	dig_in_cap = 1
@@ -109,7 +109,7 @@ icbm = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.10
+		supply_consumption = 0.05
 	}
 
 	max_fort = 1
@@ -160,7 +160,7 @@ submarine_launched_ballistic_missile = {
 	max_fort = 1
 
 	navy_base = {
-		supply_consumption = 0.10
+		supply_consumption = 0.05
 	}
 
 	dig_in_cap = 1
@@ -675,7 +675,7 @@ modern_rifles = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.02
+		supply_consumption = 0.05
 	}
 
 	ai_chance = {
@@ -719,7 +719,7 @@ precision_long_ranged_weapons = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.02
+		supply_consumption = 0.05
 	}
 	
 	ai_chance = {
@@ -769,7 +769,7 @@ spec_ops = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.02
+		supply_consumption = 0.05
 	}
 	
 	ai_chance = {
@@ -818,7 +818,7 @@ lightweight_small_arms = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.02
+		supply_consumption = 0.1
 	}
 		
 	ai_chance = {
@@ -867,7 +867,7 @@ adaptive_camouflage = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.02
+		supply_consumption = 0.1
 	}
 	
 	ai_chance = {
@@ -911,7 +911,7 @@ future_force_warrior = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.02
+		supply_consumption = 0.1
 	}
 	
 	ai_chance = {
@@ -1040,7 +1040,7 @@ main_battle_tank = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.05
 	}
 
 	ai_chance = {
@@ -1083,7 +1083,7 @@ missile_armed_tanks = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.05
 	}
 		
 	ai_chance = {
@@ -1126,7 +1126,7 @@ second_generation_tanks = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.1
 	}
 		
 	ai_chance = {
@@ -1169,7 +1169,7 @@ third_generation_tanks = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.1
 	}
 	
 	ai_chance = {
@@ -1213,7 +1213,7 @@ thirdplus_generation_tanks = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.1
 	}
 
 	ai_chance = {
@@ -1257,7 +1257,7 @@ mounted_combat_system = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.15
 	}
 	
 	ai_chance = {
@@ -1301,7 +1301,7 @@ electric_gun_technology = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.1
 	}
 
 	ai_chance = {
@@ -1345,7 +1345,7 @@ fourth_generation_tanks = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.1
 	}
 	
 	ai_chance = {
@@ -1486,7 +1486,7 @@ surface_to_air_missile = {
 	unciv_military = yes
 
 	army_base = {
-		supply_consumption = 0.01
+		supply_consumption = 0.05
 	}
 	
 	ai_chance = {
@@ -1533,8 +1533,19 @@ third_generation_jet_fighters = {
 	cost = 7200
 	unciv_military = yes
 
-	army_base = {
-		supply_consumption = 0.01
+	#Bomber 
+	bomber = {
+	supply_consumption = 0.15
+	}
+
+	#Interceptor Fighter 
+	cavalry = {
+	supply_consumption = 0.15
+	}
+
+	#Attack Helicopters
+	missile = {
+	supply_consumption = 0.1
 	}
 	
 	ai_chance = {
@@ -1584,10 +1595,21 @@ close_air_support = {
 	#Multi-Role Fighter
 	activate_unit = modern_fighter
 
-	army_base = {
-		default_organisation = 5
-		supply_consumption = 0.1
+	#Bomber 
+	bomber = {
+	supply_consumption = 0.15
 	}
+
+	#Interceptor Fighter 
+	cavalry = {
+	supply_consumption = 0.15
+	}
+
+	#Attack Helicopters
+	missile = {
+	supply_consumption = 0.1
+	}
+	
 	
 	ai_chance = {
 		factor = 1.1
@@ -1628,9 +1650,23 @@ fourth_generation_jets = {
 	cost = 12600
 	unciv_military = yes
 	
-	army_base = {
-		default_organisation = 5
-		supply_consumption = 0.05
+	#Bomber 
+	bomber = {
+	supply_consumption = 0.15
+	}
+
+	#Interceptor Fighter 
+	cavalry = {
+	supply_consumption = 0.15
+	}
+
+	#Attack Helicopters
+	missile = {
+	supply_consumption = 0.1
+	}
+		#Multi-Role Fighter
+	modern_fighter = {
+	supply_consumption = 0.2
 	}
 	
 	ai_chance = {
@@ -1672,8 +1708,23 @@ stealth_aircraft = {
 	cost = 12600
 	unciv_military = yes
 
-	army_base = {
-		supply_consumption = 0.01
+		#Bomber 
+	bomber = {
+	supply_consumption = 0.3
+	}
+
+	#Interceptor Fighter 
+	cavalry = {
+	supply_consumption = 0.2
+	}
+
+	#Attack Helicopters
+	missile = {
+	supply_consumption = 0.15
+	}
+		#Multi-Role Fighter
+	modern_fighter = {
+	supply_consumption = 0.35
 	}
 	
 	ai_chance = {
@@ -1715,8 +1766,24 @@ fifth_generation_jets = {
 	cost = 14400
 	unciv_military = yes
 
-	army_base = {
-		supply_consumption = 0.01
+	
+	#Bomber 
+	bomber = {
+	supply_consumption = 0.3
+	}
+
+	#Interceptor Fighter 
+	cavalry = {
+	supply_consumption = 0.2
+	}
+
+	#Attack Helicopters
+	missile = {
+	supply_consumption = 0.15
+	}
+		#Multi-Role Fighter
+	modern_fighter = {
+	supply_consumption = 0.35
 	}
 	
 	ai_chance = {
@@ -1758,14 +1825,25 @@ sixth_generation_jets = {
 	cost = 18000
 	unciv_military = yes
 
-	army_base = {
-		supply_consumption = 0.01
+		#Bomber 
+	bomber = {
+	supply_consumption = 0.3
+	}
+
+	#Interceptor Fighter 
+	cavalry = {
+	supply_consumption = 0.2
+	}
+
+	#Attack Helicopters
+	missile = {
+	supply_consumption = 0.15
+	}
+		#Multi-Role Fighter
+	modern_fighter = {
+	supply_consumption = 0.35
 	}
 	
-	army_base = {
-		default_organisation = 5
-		supply_consumption = 0.10
-	}
 	ai_chance = {
 		factor = 1.5
 		modifier = {
@@ -1808,9 +1886,23 @@ next_gen_bombers = {
 	year = 2070
 	cost = 25200
 	
-	army_base = {
-		default_organisation = 5
-		supply_consumption = 0.10
+		#Bomber 
+	bomber = {
+	supply_consumption = 0.5
+	}
+
+	#Interceptor Fighter 
+	cavalry = {
+	supply_consumption = 0.2
+	}
+
+	#Attack Helicopters
+	missile = {
+	supply_consumption = 0.15
+	}
+		#Multi-Role Fighter
+	modern_fighter = {
+	supply_consumption = 0.35
 	}
 	
 	unciv_military = yes
@@ -1868,7 +1960,7 @@ cold_war_doctrine = {
 	regular_experience_level = 5
 
 	army_base = {
-		supply_consumption = 0.10
+		supply_consumption = 0.05
 	}
 
 	ai_chance = {


### PR DESCRIPTION
Reduced supply increase of last update, specifically planes. The supply increase now only apply to them, simulating rapidly increasing cost in air force, without increasing overall supply needed. Reduced early tech troop discipline increase, reduced war machines' discipline increase to nerf pure tank army.