### PR TITLE
Update submarine.txt

### DIFF
--- a/CWE/units/submarine.txt
+++ b/CWE/units/submarine.txt
@@ -18,7 +18,7 @@ submarine = {
 	#Core Abilities
 	priority = 10
 	max_strength = 100
-	default_organisation = 35
+	default_organisation = 15
 	maximum_speed = 10
 	weighted_value = 5.0
 	can_build_overseas = yes
@@ -29,17 +29,17 @@ submarine = {
 	build_cost = {
 		ships = 20
 		weaponry = 10
-		fuel = 20
+		fuel = 10
 		optics = 5
 	}
 	min_port_level = 3
 	limit_per_port = -1
-	supply_consumption_score = 3.5
+	supply_consumption_score = 5
 	
 	supply_consumption = 1.0
 	supply_cost = {
 		ammunition = 2
-		fuel = 2
+		fuel = 1
 		canned_food = 0.4
 		clothes = 0.05
 		footwear = 0.05


### PR DESCRIPTION
Problem: subs are these unkillable evasion tank that cost as much as capital ship. They are not meant to fight enemy head on in practice, more of a hit and run. 

Solution: significantly reduced organization to reduce how much it can stay in fight tanking shots. Increased port consumption to make them less spammable, and reduced cost to compensate for their reduced stats. I choose fuel cost to reduce, because these sub's stat reflects that of a nuclear submarine, not the far cheaper diesel electric attack subs.