### PR TITLE
Update Attack Helicopters.txt

### DIFF
--- a/CWE/units/Attack Helicopters.txt
+++ b/CWE/units/Attack Helicopters.txt
@@ -11,7 +11,7 @@ missile = {
 	#Core Abilities
 	priority = 35
 	max_strength = 3
-	default_organisation = 30
+	default_organisation = 20
 	maximum_speed = 6.00
 	weighted_value = 6.0
 
@@ -21,14 +21,14 @@ missile = {
 	# cost 4M * 100 = 0.4B
 	build_cost = {
 		aeroplanes = 6.5
-		weaponry = 5
+		weaponry = 15
 		fuel = 12.5
-		optics = 2.5
+		optics = 10
 	}
 	
 	supply_consumption = 1.0
 	supply_cost = {
-		ammunition = 0.1
+		ammunition = 0.5
 		canned_food = 0.02
 		fuel = 0.3
 		clothes = 0.01
@@ -38,8 +38,8 @@ missile = {
 	#Land Abilties
 	reconnaissance = 2
 	attack = 14
-	defence = 6
-	discipline = 1.0
+	defence = 16
+	discipline = 0.75
 	support = 0.0
 	maneuver = 3
 }


### PR DESCRIPTION
Increased stats of attack helicopter, but made it much more expensive. It would be defense equivalent of tanks. It has 0.75 discipline and reduced org to simulate high firepower but low staying power, in contrast to infantry which is also defense oriented with more org. This means a pure helicopter army will deal high damage but will not stay long in front line.