### PR TITLE
Restored the US destroyer fleet

### DIFF
--- a/CWE/history/units/1992/USA_oob.txt
+++ b/CWE/history/units/1992/USA_oob.txt
@@ -2449,15 +2449,15 @@ navy = {
 	}
 	ship = {
 		name = "USS John Hancock (DD-981)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Mahan (DDG-72)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Barry (DDG-52)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Paul (FF-1080)"
@@ -2489,7 +2489,7 @@ navy = {
 	}
 	ship = {
 		name = "USS Briscoe (DD-977)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS John C. Calhoun (SSBN-630)"
@@ -2501,7 +2501,7 @@ navy = {
 	location = 139
 	ship = {
 		name = "USS Stump (DD-978)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Inchon (LPH/MCS-12)"
@@ -2509,11 +2509,11 @@ navy = {
 	}
 	ship = {
 		name = "USS Nicholson (DD-982)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Comte de Grasse (DD-974)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Dale (CG-19)"
@@ -2545,15 +2545,15 @@ navy = {
 	}
 	ship = {
 		name = "USS Cushing (DD-985)"
-		type = modern_destroyer
+		type = destroyer
 	}	
 	ship = {
 		name = "USS John Young (DD-973)"
-		type = modern_destroyer
+		type = destroyer
 	}	
 	ship = {
 		name = "USS Harry W. Will (DD-986)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Ouellet (FF-1077)"
@@ -2573,15 +2573,15 @@ navy = {
 	location = 205
 	ship = {
 		name = "USS Thorn (DD-988)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS O'Bannon (DD-987)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Ingersoll (DD-990)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Fanning (FF-1076)"
@@ -2609,11 +2609,11 @@ navy = {
 	}
 	ship = {
 		name = "USS Spruance (DD-963)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Hayler (DD-997)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Joseph Hewes (FF-1078)"
@@ -2633,7 +2633,7 @@ navy = {
 	}
 	ship = {
 		name = "USS Leahy (DLG-16)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Lake Champlain (CG-57)"
@@ -2641,7 +2641,7 @@ navy = {
 	}
 	ship = {
 		name = "USS Arleigh Burke (DDG-51)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Simon Bolivar (SSBN-641)"
@@ -2669,15 +2669,15 @@ navy = {
 	location = 219
 	ship = {
 		name = "USS Macdonough (DDG-39)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Scott (DDG-995)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Dahlgren (DDG-43)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Aylwin (FF-1081)"
@@ -2701,7 +2701,7 @@ navy = {
 	}
 	ship = {
 		name = "USS Goldsborough (DDG-20)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Robert E. Peary (FF-1073)"
@@ -2709,11 +2709,11 @@ navy = {
 	}
 	ship = {
 		name = "USS Waddell (DDG-24)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Kinkaid (DD-965)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS New Orleans (LPH-11)"
@@ -2721,7 +2721,7 @@ navy = {
 	}	
 	ship = {
 		name = "USS Fletcher (DD-992)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Antietam (CG-54)"
@@ -2737,7 +2737,7 @@ navy = {
 	}
 	ship = {
 		name = "USS Oldendorf (DD-972)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Halsey (CG-23)"
@@ -2822,15 +2822,15 @@ navy = {
 	}
 	ship = {
 		name = "USS Arthur W. Radford (DD-968)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Peterson (DD-969)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS David R. Ray (DD-971)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Haddock (SSN-621)"
@@ -2886,7 +2886,7 @@ navy = {
 	}
 	ship = {
 		name = "USS O'Brien (DD-975)"
-		type = modern_destroyer
+		type = destroyer
 	}
 }
 navy = {
@@ -2927,39 +2927,39 @@ navy = {
 	}
 	ship = {
 		name = "USS Hewitt (DD-966)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Leftwich (DD-984)"
-		type = modern_destroyer
+		type = destroyer
 	}	
 	ship = {
 		name = "USS Moosbrugger (DD-980)"
-		type = modern_destroyer
+		type = destroyer
 	}	
 	ship = {
 		name = "USS Merrill (DD-976)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Elliot (DD-967)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Conolly (DD-979)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Kidd (DDG-993)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Caron (DD-970)"
-		type = modern_destroyer
+		type = destroyer
 	}	
 	ship = {
 		name = "USS Fife (DD-991)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Tarawa (LHA-1)"
@@ -3004,19 +3004,19 @@ navy = {
 	}
 	ship = {
 		name = "USS Paul F. Foster (DD-964)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Deyo (DD-989)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Chandler (DDG-996)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS John Rodgers (DD-983)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS La Salle (AGF-3)"
@@ -3074,7 +3074,7 @@ navy = {
 	
 	ship = {
 		name = "USS Callaghan (DDG-994)"
-		type = modern_destroyer
+		type = destroyer
 	}
 	ship = {
 		name = "USS Bonhomme Richard (LHD-6)"


### PR DESCRIPTION
Bug: commit ac023bc62755c51071fd8e13d9adc60be8fe768d accidentally converted all destroyers in the 1992 start into nuclear aircraft carriers.

Solution: replace all modern_destroyers with destroyers