### PR TITLE
Update triggered_modifiers.txt

### DIFF
--- a/CWE/common/triggered_modifiers.txt
+++ b/CWE/common/triggered_modifiers.txt
@@ -1678,7 +1678,7 @@ grand_navy = {
 
 grand_army = {
 	trigger = {
-	total_amount_of_divisions = 100
+	total_amount_of_divisions = 150
 	civilized = yes
 	}
 	icon = 9


### PR DESCRIPTION
Grand army now takes 150 divisions to account for lesser cost of land units.