### PR TITLE
Update buildings.txt

### DIFF
--- a/CWE/common/buildings.txt
+++ b/CWE/common/buildings.txt
@@ -623,7 +623,7 @@ paper_factory = {
 
 	production_type = paper_factory
 	pop_build_factory = yes
-	default_enabled = no	
+	default_enabled = yes	
 }
 
 glass_factory = {


### PR DESCRIPTION
Low tech product such as paper is now enabled from default, no longer locked behind commerce techs.