### PR TITLE
Update commerce_inventions.txt

### DIFF
--- a/CWE/inventions/commerce_inventions.txt
+++ b/CWE/inventions/commerce_inventions.txt
@@ -984,7 +984,6 @@ john_maynard_keynes = {
 		}
 	}
 	effect = {
-		activate_building = paper_factory  
 		permanent_prestige = 3 
 		factory_goods_throughput = { financial_services = 0.02 }
 	}
@@ -1772,7 +1771,7 @@ anti_trust_laws = {
 		}
 	}
 	effect = {
-		activate_building = petroleum_plastics_factory
+		factory_output = 0.01
 	}
 }
 price_fixing = {


### PR DESCRIPTION
Low tech product like paper is no longer locked behind commerce tech. Plastic tech is unlocked in the industry tech already, so anti-trust law instead of unlock plastic it improves factory output.