### PR TITLE
Update goods.txt

### DIFF
--- a/CWE/common/goods.txt
+++ b/CWE/common/goods.txt
@@ -207,7 +207,7 @@ industrial_goods = {
 	}
 
 	electric_gear = {
-		cost = 4
+		cost = 3.5
 		color = { 255 255 0 }
 	}
 


### PR DESCRIPTION
Despite last nerf, electric gear is still profitable to a silly degree. dropping price from 4 to 3.5 Hopefully bring it to place.