### PR TITLE
Jewish Oblast Namechange + More Jewish Pops

### DIFF
--- a/CWE/history/pops/1946.1.1/Russia.txt
+++ b/CWE/history/pops/1946.1.1/Russia.txt
@@ -12698,22 +12698,22 @@
 	farmers = {
 		culture = russian
 		religion =  orthodox 
-		size = 21745
+		size = 14745
 	 } 
 	farmers = {
 		culture = russian
 		religion = secularism
-		size = 3762
+		size = 2062
 	 } 
 	farmers = {
 		culture = jewish
 		religion =  jewish 
-		size = 300
+		size = 7300
 	 } 
 	farmers = {
 		culture = jewish
 		religion = secularism
-		size = 51
+		size = 1251
 	 } 
 	farmers = {
 		culture = ukrainian

--- a/CWE/history/pops/1950.1.1/Russia.txt
+++ b/CWE/history/pops/1950.1.1/Russia.txt
@@ -12698,22 +12698,22 @@
 	farmers = {
 		culture = russian
 		religion =  orthodox 
-		size = 21745
+		size = 15745
 	 } 
 	farmers = {
 		culture = russian
 		religion = secularism
-		size = 3762
+		size = 2362
 	 } 
 	farmers = {
 		culture = jewish
 		religion =  jewish 
-		size = 300
+		size = 6300
 	 } 
 	farmers = {
 		culture = jewish
 		religion = secularism
-		size = 51
+		size = 1051
 	 } 
 	farmers = {
 		culture = ukrainian


### PR DESCRIPTION
Birobidzhan is the name of the capital of the Jewish Autonomous Oblast.

The [wiki page](https://en.wikipedia.org/wiki/Jewish_Autonomous_Oblast) says that around 25% of the population was Jewish in 1948.