### PR TITLE
Fix to enourmous Israeli pop growth.

### DIFF
--- a/CWE/common/event_modifiers.txt
+++ b/CWE/common/event_modifiers.txt
@@ -5926,8 +5926,13 @@ prestige = 0.1
 icon = 3
 }
 
-demographic_mennonites = { population_growth = 0.01 }
-demographic_haredim_jewish = { population_growth = 0.01 }
+demographic_mennonites = {
+icon = 17
+}
+
+demographic_haredim_jewish = {
+icon = 17
+}
 
 fertility_timer = {
    icon = 17


### PR DESCRIPTION
The event that multiplies Haredi pops every 10 years also gave Israel a perpetual, national 1% pop growth modifier.