### PR TITLE
Added Dutch Train Hostage Crisis of 1975

### DIFF
--- a/CWE/events/netherlands.txt
+++ b/CWE/events/netherlands.txt
@@ -243,6 +243,27 @@ country_event = {
   }
 }
 
+#Dutch Train Hostage Crisis of 1975
+country_event = {
+  id = 8006805
+  title = EVT_8006805_NAME
+  desc = EVT_8006805_DESC
+  picture = "1975_dutch_train_crisis"
+  fire_only_once = yes
+
+  trigger = {
+    tag = NET 
+    year = 1975 NOT = { year = 1990 }
+  }
+  
+  mean_time_to_happen = { months = 11 }
+
+  option = {
+    name = EVT_8006805_A
+    prestige = -5
+	badboy = 0.5
+	}  
+ }
 
 #Assassination of Pim Fortuyn
 


### PR DESCRIPTION
New flavour event. This is not the only act of terrorism committed by South Moluccans in this period, so more could be added later. IMPORTANT: STILL NEEDS TO BE ADDED TO LOCALISATION