### PR TITLE
Merged Ryukyuan into Japanese

### DIFF
--- a/CWE/common/cultures.txt
+++ b/CWE/common/cultures.txt
@@ -1422,12 +1422,12 @@ far_east_asian = {
 		last_names = { Aritomo Goro Gentaro Gonnohyoe Heihachiro Hiroshi Hikonojo Hyoe Hayao Iwao Jiro Jinzaburo Kiyotaka Kuranosuke Kozo Kantaro Koichiro Kagenori Kageaki Kotohito Keisuke Kazushige Kenkichi Maresuke Masujiro Michisura Masatake Mitsuomi Mitsue Mineo Nariaki Nobuyoshi Rokuro Sukeyuki Sukenori Shoin Sumiyoshi Samata Soroku Shichiro Shigeto Sotokichi Shigeru Sadao Shinsaku Takayoshi Takamori Toshimichi Tsugumichi Tadakuni Tomonosuke Taro Toshiyoshi Tetsutaro Taruhito Takeaki Tamemoto Tomasaburo Yoshika Yoshinobu Yoshimichi Yoshida Yasukata Yahachi Yusaku Yoshifuru Yoshinori Yasuyoshi Ieyasu
 		}
 	}
-	ryukyuan = { # tag = RYK
-		 #!religion = { shinto }
-		 color = { 250 250 210 }
-		 first_names = { Aritomo Goro Gentaro Gonnohyoe Heihachiro Hiroshi Hikonojo Hyoe Hayao Iwao Jiro Jinzaburo Kuranosuke Kozo Kantaro Koichiro Kagenori Kiyotaka Kageaki Kotohito Keisuke Kazushige Kenkichi Maresuke Masujiro Michisura Masatake Mitsuomi Mitsue Mineo Nariaki Nobuyoshi Rokuro Sukeyuki Sukenori Shoin Sumiyoshi Samata Soroku Shichiro Shigeto Sotokichi Shigeru Sadao Shinsaku Takayoshi Takamori Toshimichi Tsugumichi Tadakuni Tomonosuke Taro Toshiyoshi Tetsutaro Taruhito Takeaki Tamemoto Tomasaburo Yoshika Yoshinobu Yoshimichi Yoshida Yasukata Yahachi Yusaku Yoshifuru Yoshinori Yasuyoshi }
-		 last_names = { Arisugawa Arichi Akiyama Araki Dewa Enomoto Hasegawa Honjo Ito Inoue Ichinohe Itagaki Kido Kuroda Katsura Kodama Kabayama Kawamura Kuroki Kawakami Kamimura Kataoka Kamio Kato Kanin Katsu Makino Muto Minami Masaki Matsudaira Nakamuta Nogi Nire Nozu Okubo Oyama Omura Oku Okada Osumi Saigo Suzuki Sato Sakura Shibayama Shimamura Shirakawa Togo Takashima Tsuboi Tachibana Terauchi Tamon Takasugi Tokugawa Uehara Uryu Ugaki Ueda Yamagata Yamamoto Yamakawa Yashiro Yui Yamashita Yamaya }
-	}
+	#ryukyuan = { # tag = RYK
+	#	 #!religion = { shinto }
+	#	 color = { 250 250 210 }
+	#	 first_names = { Aritomo Goro Gentaro Gonnohyoe Heihachiro Hiroshi Hikonojo Hyoe Hayao Iwao Jiro Jinzaburo Kuranosuke Kozo Kantaro Koichiro Kagenori Kiyotaka Kageaki Kotohito Keisuke Kazushige Kenkichi Maresuke Masujiro Michisura Masatake Mitsuomi Mitsue Mineo Nariaki Nobuyoshi Rokuro Sukeyuki Sukenori Shoin Sumiyoshi Samata Soroku Shichiro Shigeto Sotokichi Shigeru Sadao Shinsaku Takayoshi Takamori Toshimichi Tsugumichi Tadakuni Tomonosuke Taro Toshiyoshi Tetsutaro Taruhito Takeaki Tamemoto Tomasaburo Yoshika Yoshinobu Yoshimichi Yoshida Yasukata Yahachi Yusaku Yoshifuru Yoshinori Yasuyoshi }
+	#	 last_names = { Arisugawa Arichi Akiyama Araki Dewa Enomoto Hasegawa Honjo Ito Inoue Ichinohe Itagaki Kido Kuroda Katsura Kodama Kabayama Kawamura Kuroki Kawakami Kamimura Kataoka Kamio Kato Kanin Katsu Makino Muto Minami Masaki Matsudaira Nakamuta Nogi Nire Nozu Okubo Oyama Omura Oku Okada Osumi Saigo Suzuki Sato Sakura Shibayama Shimamura Shirakawa Togo Takashima Tsuboi Tachibana Terauchi Tamon Takasugi Tokugawa Uehara Uryu Ugaki Ueda Yamagata Yamamoto Yamakawa Yashiro Yui Yamashita Yamaya }
+	#}
 
 	union = JAP
 
@@ -1662,23 +1662,13 @@ south_asian_indian = {
 	}
 	gujarati = {
 		color = {99 12 89}
-		first_names = { Chetan Fakirbhai Jivraj Madhavsingh Khemchand Manubhai Bharatsingh Balwantry Chabildas Maniraj 
-			
-		}
-		
-		last_names = { Pansara Vaghela Solanki Modhvadia Mehta Baro Parmar
-               
-		}
+		first_names = { Chetan Fakirbhai Jivraj Madhavsingh Khemchand Manubhai Bharatsingh Balwantry Chabildas Maniraj }
+		last_names = { Pansara Vaghela Solanki Modhvadia Mehta Baro Parmar }
 	}
 	marathi = {
 		color = {190 220 10}
-		first_names = { Venkatji Shahuji Pratapsinha Rajaram Shivaji Shambhaji Balaji Bajirao Madhava Narayan Raghunath Sawai 
-			
-		}
-		
-		last_names = { "Appa Sahib" "Bowa Sahib" Phadnis Narayan Rao Ballal "Baji Rao" Bhat
-               
-		}
+		first_names = { Venkatji Shahuji Pratapsinha Rajaram Shivaji Shambhaji Balaji Bajirao Madhava Narayan Raghunath Sawai }
+		last_names = { "Appa Sahib" "Bowa Sahib" Phadnis Narayan Rao Ballal "Baji Rao" Bhat }
 	}
 
 	punjabi = {

--- a/CWE/history/countries/JAP - Japan.txt
+++ b/CWE/history/countries/JAP - Japan.txt
@@ -1,6 +1,5 @@
 capital = 1649
 primary_culture = japanese
-culture = ryukyuan
 culture = ainu
 religion = secularism
 government = hms_government

--- a/CWE/history/countries/RYK - Ryukyu.txt
+++ b/CWE/history/countries/RYK - Ryukyu.txt
@@ -1,6 +1,5 @@
 capital = 1678
-primary_culture = ryukyuan
-culture = japanese
+primary_culture = japanese
 religion = secularism
 government = hms_government
 plurality = 18.0

--- a/CWE/history/pops/1946.1.1/Japan.txt
+++ b/CWE/history/pops/1946.1.1/Japan.txt
@@ -1044,12 +1044,12 @@
 		size = 22460
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 34693
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 7486
 	 } 

--- a/CWE/history/pops/1946.1.1/USA.txt
+++ b/CWE/history/pops/1946.1.1/USA.txt
@@ -8694,82 +8694,82 @@
 #Okinawa - Okinawa (699000/174750 POPS)
 1678 = {
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 430
 	 } 
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 93
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1724
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 372
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 3592
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 775
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 718
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 154
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 861
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 186
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1436
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 310
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 4685
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 1011
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 105613
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 22791
 	 } 
@@ -8777,82 +8777,82 @@
 #Amari - Amari (222000/55500 POPS)
 1679 = {
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 136
 	 } 
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 29
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 547
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 118
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1140
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 246
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 227
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 49
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 273
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 59
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 456
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 98
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1487
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 321
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 33541
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 7238
 	 } 

--- a/CWE/history/pops/1950.1.1/Japan.txt
+++ b/CWE/history/pops/1950.1.1/Japan.txt
@@ -1044,12 +1044,12 @@
 		size = 22460
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 34693
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 7486
 	 } 

--- a/CWE/history/pops/1950.1.1/USA.txt
+++ b/CWE/history/pops/1950.1.1/USA.txt
@@ -8694,82 +8694,82 @@
 #Okinawa - Okinawa (699000/174750 POPS)
 1678 = {
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 430
 	 } 
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 93
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1724
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 372
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 3592
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 775
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 718
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 154
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 861
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 186
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1436
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 310
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 4685
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 1011
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 105613
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 22791
 	 } 
@@ -8777,82 +8777,82 @@
 #Amari - Amari (222000/55500 POPS)
 1679 = {
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 136
 	 } 
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 29
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 547
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 118
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1140
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 246
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 227
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 49
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 273
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 59
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 456
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 98
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1487
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 321
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 33541
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 7238
 	 } 

--- a/CWE/history/pops/1992.1.1/Japan.txt
+++ b/CWE/history/pops/1992.1.1/Japan.txt
@@ -1284,12 +1284,12 @@
 		size = 132432
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 18030
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 44144
 	 } 
@@ -4141,102 +4141,102 @@
 #Okinawa - Okinawa (1031000/257750 POPS)
 1678 = {
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 77
 	 } 
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 189
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 309
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 758
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1494
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 3660
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 448
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 1097
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 448
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 1097
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 1494
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 3660
 	 } 
 	clerks = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 2574
 	 } 
 	clerks = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 6302
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 2188
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 5356
 	 } 
 	craftsmen = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 8109
 	 } 
 	craftsmen = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 19853
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 57602
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 141025
 	 } 
@@ -4244,102 +4244,102 @@
 #Amari - Amari (327000/81750 POPS)
 1679 = {
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 24
 	 } 
 	officers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 59
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 98
 	 } 
 	soldiers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 240
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 474
 	 } 
 	aristocrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 1160
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 142
 	 } 
 	bureaucrats = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 347
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 142
 	 } 
 	capitalists = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 347
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 474
 	 } 
 	clergymen = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 1160
 	 } 
 	clerks = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 816
 	 } 
 	clerks = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 1998
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 693
 	 } 
 	artisans = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 1699
 	 } 
 	craftsmen = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 2572
 	 } 
 	craftsmen = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 6296
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion =  shinto 
 		size = 18270
 	 } 
 	farmers = {
-		culture = ryukyuan
+		culture = japanese
 		religion = secularism
 		size = 44730
 	 } 


### PR DESCRIPTION
Since other small cultures where consolidaded I thought maybe Ryukyuan could be merged into Japanese.

While the culture has a tag attached to it I thought the Ryukyuan is small enough to be merged into Japanese. But I´m not sure what the requirements for culture consolidation are.

I didn´t remove it from the cultures file only commented it out in case it could be used again.

