### PR TITLE
Bugfixes for superstate irrdentist claims

### DIFF
--- a/CWE/decisions/claim_greater.txt
+++ b/CWE/decisions/claim_greater.txt
@@ -5359,7 +5359,7 @@ NOT = { government = democracy government = hms_government }
 			badboy = 12
 			set_country_flag = claim_greater_latinamerica
 			any_country = {
-				any_owned = { limit = { NOT = { is_core = XSU } NOT = { is_core = USA } NOT = { is_core = CAN } OR = { continent = south_america continent = north_america } } add_core = XSU } 
+				all_core = { limit = { NOT = { is_core = XSU } NOT = { is_core = USA } NOT = { is_core = CAN } NOT = { is_core = BEU } NOT = { is_core = SPM } NOT = { is_core = NFL } OR = { continent = south_america continent = north_america } } add_core = XSU } 
 			}
 		}
 
@@ -5398,7 +5398,7 @@ NOT = { government = democracy government = hms_government }
 			badboy = 12
 			set_country_flag = claim_greater_europe
 			any_country = {
-				any_owned = { limit = { NOT = { is_core = XEU } OR = { continent = europe } } add_core = XEU }
+				all_core = { limit = { NOT = { is_core = XEU } OR = { continent = europe } } add_core = XEU }
 			}
 		}
 
@@ -5437,7 +5437,7 @@ NOT = { government = democracy government = hms_government }
 			badboy = 12
 			set_country_flag = claim_greater_africa
 			any_country = {
-				any_owned = { limit = { NOT = { is_core = XAU } OR = { continent = africa is_core = EGY is_core = SUD is_core = SSU is_core = LBY is_core = TUN is_core = ALG is_core = MOR is_core = MAU } } add_core = XAU } 
+				all_core = { limit = { NOT = { is_core = XAU } OR = { continent = africa is_core = EGY is_core = SUD is_core = SSU is_core = LBY is_core = TUN is_core = ALG is_core = MOR is_core = MAU } } add_core = XAU } 
 			}
 		}
 	}
@@ -5475,7 +5475,7 @@ NOT = { government = democracy government = hms_government }
 			badboy = 12
 			set_country_flag = claim_greater_oceania
 			any_country = {
-				any_owned = { limit = { NOT = { is_core = XPI } OR = { continent = oceania } } add_core = XPI } 
+				all_core = { limit = { NOT = { is_core = XPI } OR = { continent = oceania } } add_core = XPI } 
 			}
 		}
 
@@ -5514,7 +5514,7 @@ NOT = { government = democracy government = hms_government }
 			badboy = 12
 			set_country_flag = claim_greater_arabia
 			any_country = {
-				any_owned = { limit = { NOT = { is_core = XAL } NOT = { is_core = PER } NOT = { is_core = ARM } NOT = { is_core = AZB } NOT = { is_core = GEO } NOT = { is_core = TUR } OR = { continent = mena } } add_core = XAL } 
+				all_core = { limit = { NOT = { is_core = XAL } NOT = { is_core = PER } NOT = { is_core = ARM } NOT = { is_core = AZB } NOT = { is_core = GEO } NOT = { is_core = TUR } OR = { continent = mena } } add_core = XAL } 
 			}
 		}
 

--- a/CWE/decisions/claim_greater.txt
+++ b/CWE/decisions/claim_greater.txt
@@ -5398,8 +5398,7 @@ NOT = { government = democracy government = hms_government }
 			badboy = 12
 			set_country_flag = claim_greater_europe
 			any_country = {
-				limit = { capital_scope = { continent = europe } }
-				all_core = { add_core = XEU }
+				any_owned = { limit = { NOT = { is_core = XEU } OR = { continent = europe } } add_core = XEU }
 			}
 		}
 
@@ -5438,15 +5437,8 @@ NOT = { government = democracy government = hms_government }
 			badboy = 12
 			set_country_flag = claim_greater_africa
 			any_country = {
-				limit = {
-					OR = {
-						tag = EGY tag = SUD tag = LBY tag = TUN tag = ALG tag = MOR
-						capital_scope = { continent = africa }
-					}
-				}
-				all_core = { add_core = XAU }
+				any_owned = { limit = { NOT = { is_core = XAU } OR = { continent = africa is_core = EGY is_core = SUD is_core = SSU is_core = LBY is_core = TUN is_core = ALG is_core = MOR is_core = MAU } } add_core = XAU } 
 			}
-			2124 = { add_core = XAU } #Mayotte
 		}
 	}
 	
@@ -5483,7 +5475,7 @@ NOT = { government = democracy government = hms_government }
 			badboy = 12
 			set_country_flag = claim_greater_oceania
 			any_country = {
-				any_owned = { limit = { continent = oceania NOT = { is_core = XPI } } add_core = XPI } 
+				any_owned = { limit = { NOT = { is_core = XPI } OR = { continent = oceania } } add_core = XPI } 
 			}
 		}
 
@@ -5502,8 +5494,7 @@ NOT = { government = democracy government = hms_government }
 			part_of_sphere = no
 			has_unclaimed_cores = no
 			NOT = { 
-				OR = { 
-					ruling_party_ideology = socialist
+				OR = {
 					ruling_party_ideology = progressive
 					ruling_party_ideology = liberal 
 				}
@@ -5511,6 +5502,7 @@ NOT = { government = democracy government = hms_government }
 			is_vassal = no
 			prestige = 45
 			OR = {
+				ruling_party_ideology = socialist #Arab socialists are historically Pan-Arabists
 				ruling_party_ideology = populist
 				ruling_party_ideology = nationalist
 				ruling_party_ideology = communist
@@ -5521,8 +5513,8 @@ NOT = { government = democracy government = hms_government }
 		effect = {
 			badboy = 12
 			set_country_flag = claim_greater_arabia
-			any_country = { 
-				any_owned = { limit = { pop_majority_culture = arab NOT = { is_core = XAL } } add_core = XAL } 
+			any_country = {
+				any_owned = { limit = { NOT = { is_core = XAL } NOT = { is_core = PER } NOT = { is_core = ARM } NOT = { is_core = AZB } NOT = { is_core = GEO } NOT = { is_core = TUR } OR = { continent = mena } } add_core = XAL } 
 			}
 		}
 


### PR DESCRIPTION
Fixed coring problems for XEU, XPI, XAU, and XAL claims and verified the fixes (before, it just gave infamy and zero cores); Gave XAL socialist ideology the ability to take the decision as Arab socialists are historically Pan-Arabists and it makes no sense for them to not be able to take irredentist claims after forming their own non-UAR superstate.