### PR TITLE
Create Toggle Superstates.txt

### DIFF
--- a/CWE/events/Toggle Superstates.txt
+++ b/CWE/events/Toggle Superstates.txt
@@ -1,0 +1,31 @@
+#Toggle Superstates
+#Enable or disable post-2030s superstate formation in the mod
+#Activate via opening the console and keying in 'event 669967'
+country_event = {
+	id = 669967
+	title = "Toggle Superstates"
+	desc = "This event enables or disables the formation of superstates. Historical superstates will not be affected."
+	picture = "superstate_push"
+	
+	fire_only_once = yes
+
+	trigger = {
+		ai = no
+		NOT = { has_global_flag = superstates_toggled }
+	}
+
+	option = {
+		name = "Enable the formation of superstates"
+		set_global_flag = superstates_toggled
+		any_country = { clr_country_flag = hide_superstate }
+		clr_country_flag = hide_superstate #unhides superstate decisions for the player too
+	}
+
+	option = {
+		name = "Disable the formation of superstates"
+		set_global_flag = superstates_toggled
+		any_country = { set_country_flag = hide_superstate }
+		set_country_flag = hide_superstate #hides superstate decisions for the player too
+	}
+
+}


### PR DESCRIPTION
Allow the player to choose whether or not to disable the creation of post-2030s superstates, though historical superstates like the UAR will be unaffected for the sake of maintaining historical cohesion.
Note: the events for the first steps of creating the EU will still fire like normal, but the final step of forming the EU will be prevented.