### PR TITLE
Update artillery and army tech

### DIFF
--- a/CWE/technologies/army_tech.txt
+++ b/CWE/technologies/army_tech.txt
@@ -1205,9 +1205,6 @@ antitank_weapons = {
 	year = 1951
 	cost = 5400
 	unciv_military = yes
-
-	#Artillery
-	activate_unit = artillery
 	
 	tank = {
 		supply_consumption = 0.05
@@ -1780,7 +1777,7 @@ surface_to_air_missile = {
 }
 close_air_support = {
 	area = jet_tech
-	year = 1970
+	year = 1965
 	cost = 12600
 	unciv_military = yes
 

--- a/CWE/units/artillery.txt
+++ b/CWE/units/artillery.txt
@@ -4,7 +4,7 @@ artillery = {
 	
 	type = land
 	sprite = Artillery
-	active = no
+	active = yes
 	unit_type = support
 	floating_flag = no
 


### PR DESCRIPTION
made artillery active by default and moved back close air support tech date to 1965 due to attack helis being active before the 70s