### PR TITLE
Tweak for OPEC due to Iran's membership

### DIFF
--- a/CWE/decisions/OPEC.txt
+++ b/CWE/decisions/OPEC.txt
@@ -4,7 +4,7 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			year = 1960
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 government = theocracy } }
+			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
 			
 			#Not a club for GPs
 			is_greater_power = no
@@ -78,7 +78,7 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			has_country_modifier = opecmember
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 government = theocracy } }
+			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
 			is_vassal = no
 			any_owned_province = { trade_goods = petroleum }
 			NOT = {
@@ -113,7 +113,7 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			has_country_modifier = opecmember
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 government = theocracy } }
+			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
 			is_vassal = no
 			any_owned_province = { trade_goods = petroleum }
 			NOT = {
@@ -150,7 +150,7 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			has_country_modifier = opecmember
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 government = theocracy } }
+			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
 			is_vassal = no
 			any_owned_province = { trade_goods = petroleum }
 			NOT = {
@@ -184,7 +184,7 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			has_country_modifier = opecmember
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 government = theocracy } }
+			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
 			is_vassal = no
 			any_owned_province = { trade_goods = petroleum }
 			OR = {

--- a/CWE/decisions/OPEC.txt
+++ b/CWE/decisions/OPEC.txt
@@ -13,12 +13,20 @@ political_decisions = {
 			
 			NOT = { has_country_modifier = opecmember }
 
-			#Islamic State cannot join OPEC
-			NOT = { tag = ISI }
+			#ISIS cannot join OPEC
+			NOT = { 
+				AND = { 
+					tag = ISI
+					government = theocracy
+				} 
+			}
 		}
 		allow = {
 			is_vassal = no
 			war = no
+			
+			#Cannot join OPEC if THIS has high infamy
+			NOT = { badboy = 0.8 }
 		}
 		effect = {
 			prestige = 20

--- a/CWE/decisions/OPEC.txt
+++ b/CWE/decisions/OPEC.txt
@@ -31,6 +31,10 @@ political_decisions = {
 		effect = {
 			prestige = 20
 			add_country_modifier = { name = opecmember duration = -1 }
+			
+			#THIS starts off with meeting OPEC quotas
+			any_owned = { limit = { trade_goods = petroleum } add_province_modifier = { name = oil_medium duration = -1 } } 
+			set_country_flag = oil_medium
 		}
 		ai_will_do = { 
 			factor = 1 
@@ -89,9 +93,6 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			has_country_modifier = opecmember
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
-			is_vassal = no
-			any_owned_province = { trade_goods = petroleum }
 			NOT = {
 				OR = {
 					has_country_flag = oil_high
@@ -124,9 +125,6 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			has_country_modifier = opecmember
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
-			is_vassal = no
-			any_owned_province = { trade_goods = petroleum }
 			NOT = {
 				OR = {
 					has_country_flag = oil_high
@@ -161,9 +159,6 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			has_country_modifier = opecmember
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
-			is_vassal = no
-			any_owned_province = { trade_goods = petroleum }
 			NOT = {
 				OR = {
 					has_country_flag = oil_high
@@ -195,9 +190,6 @@ political_decisions = {
 		picture = "opec"
 		potential = {
 			has_country_modifier = opecmember
-			NOT = { OR = { government = proletarian_dictatorship government = proletarian_dictatorship1 } }
-			is_vassal = no
-			any_owned_province = { trade_goods = petroleum }
 			OR = {
 				has_country_flag = oil_high
 				has_country_flag = oil_medium

--- a/CWE/decisions/OPEC.txt
+++ b/CWE/decisions/OPEC.txt
@@ -12,6 +12,9 @@ political_decisions = {
 			any_owned_province = { trade_goods = petroleum }
 			
 			NOT = { has_country_modifier = opecmember }
+
+			#Islamic State cannot join OPEC
+			NOT = { tag = ISI }
 		}
 		allow = {
 			is_vassal = no

--- a/CWE/events/Essential events 3.txt
+++ b/CWE/events/Essential events 3.txt
@@ -814,8 +814,7 @@ country_event = {
 			NOT = { any_owned_province = { trade_goods = petroleum } } 
 			is_vassal = yes 
 			government = proletarian_dictatorship 
-			government = proletarian_dictatorship1 
-			government = theocracy
+			government = proletarian_dictatorship1
 		}
 	}
 	


### PR DESCRIPTION
Gave theocracy the ability to join OPEC and OPEC members can no longer be kicked out if they're a theocracy since Iran is still an OPEC member and was never kicked out after the Islamic Revolution
Islamic State tag can never join OPEC