### PR TITLE
Paraguyans are platinean_white_spanish

### DIFF
--- a/CWE/history/countries/PRG - Paraguay.txt
+++ b/CWE/history/countries/PRG - Paraguay.txt
@@ -1,5 +1,5 @@
 capital = 2339
-primary_culture = andean_white_spanish
+primary_culture = platinean_white_spanish
 culture = mestizo
 religion = secularism
 government = democracy


### PR DESCRIPTION
Paraguyans are platinean_white_spanish, they are not andean_white_spanish, they are culturaly more closer to Uruguay and Argentina than Bolivia, Chile and Peru.